### PR TITLE
Fix for Twitter hyperlinks being broke on the !

### DIFF
--- a/Chat/Chat.cs
+++ b/Chat/Chat.cs
@@ -626,7 +626,7 @@ namespace SignalR.Samples.Hubs.Chat {
         }
 
         private string Transform(string message, out HashSet<string> extractedUrls) {
-            const string urlPattern = @"((https?|ftp)://|www\.)[\w]+(.[\w]+)([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])";
+            const string urlPattern = @"((https?|ftp)://|www\.)[\w]+(.[\w]+)([\w\-\.,@?^=%&amp;:/~\+#!]*[\w\-\@?^=%&amp;/~\+#])";
 
             var urls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             message = Regex.Replace(message, urlPattern, m => {


### PR DESCRIPTION
Added "!" to URL regex, to support URLs like "http://twitter.com/#!/DanTup/status/112288509276065792".
