### PR TITLE
fix the scroll problem

### DIFF
--- a/Chat/Chat.css
+++ b/Chat/Chat.css
@@ -18,6 +18,11 @@
     padding: 3px;
 }
 
+#messages li img{
+   height : 16px;
+   width : 16px;
+}
+
 #users {
     width: 17%;
     height: 500px;


### PR DESCRIPTION
The problem - the script adds the message, and calls to scrollToBottom _before_ the gravatar image is loaded, and until then the image is too small. 
then the image is loaded, the element is now (delta) pixles longer, and on the next message, isNearTheEnd will return false.
