### PR TITLE
Fixed null reference exception when /msg invalid username

### DIFF
--- a/Chat/Chat.cs
+++ b/Chat/Chat.cs
@@ -516,7 +516,7 @@ namespace SignalR.Samples.Hubs.Chat
 
             if (toUser == null)
             {
-                throw new InvalidOperationException(String.Format("Couldn't find any user named '{0}'.", toUser.Name));
+                throw new InvalidOperationException(String.Format("Couldn't find any user named '{0}'.", parts[1]));
             }
 
             if (toUser == user)


### PR DESCRIPTION
Title pretty much says it all.

Ruddles (TFD on apphub chat)
