### PR TITLE
Moving unread to the front of the Title so that you can tell at a glance...

### DIFF
--- a/Chat/Chat.js
+++ b/Chat/Chat.js
@@ -421,7 +421,7 @@ $(function () {
             document.title = 'SignalR Chat';
         }
         else {
-            document.title = 'SignalR Chat (' + chat.unread + ')';
+            document.title = '(' + chat.unread + ') SignalR Chat ';
         }
     }
 


### PR DESCRIPTION
... when the window is minimized or the tabs shrink smaller than the length required to display the number of unread messages
