### PR TITLE
Fix issue #51 - Prevent too long nickname

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -88,6 +88,10 @@
     padding: 4px;
 }
 
+.users li .name {
+    word-wrap: break-word;
+}
+
 .users li.typing {
     background-image: url('Content/images/keyboard.png');
     background-repeat: no-repeat;

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -996,12 +996,12 @@ namespace JabbR
 
         private bool IsValidUserName(string name)
         {
-            return Regex.IsMatch(name, "^[A-Za-z0-9-_.]+$");
+            return Regex.IsMatch(name, "^[A-Za-z0-9-_.]{1,30}$");
         }
 
         private bool IsValidRoomName(string name)
         {
-            return Regex.IsMatch(name, "^[A-Za-z0-9-_.]+$");
+            return Regex.IsMatch(name, "^[A-Za-z0-9-_.]{1,30}$");
         }
 
         private void LeaveAllRooms(ChatUser user)


### PR DESCRIPTION
- Limit nick and room names to 30 charaters
- Update CSS to break word for nicknames too long to display
