### PR TITLE
Fix issue #118 - Rooms command has incorrect user count

### DIFF
--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -512,13 +512,7 @@ namespace JabbR
 
         void INotificationService.ShowRooms()
         {
-            var rooms = _repository.Rooms.Select(r => new
-            {
-                Name = r.Name,
-                Count = r.Users.Count
-            });
-
-            Caller.showRooms(rooms);
+            Caller.showRooms(GetRooms());
         }
 
         void INotificationService.NugeUser(ChatUser user, ChatUser targetUser)


### PR DESCRIPTION
- Do not count offline users
- Simply return the same results as GetRooms() method called by Lobby
