### PR TITLE
Log background task exceptions. Treat warnings as errors. Fixes #125

### DIFF
--- a/JabbR.Test/JabbR.Test.csproj
+++ b/JabbR.Test/JabbR.Test.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/JabbR/App_Start/Bootstrapper.cs
+++ b/JabbR/App_Start/Bootstrapper.cs
@@ -5,6 +5,7 @@ using System.Data.Entity.Migrations;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elmah;
 using JabbR.Migrations;
 using JabbR.Models;
 using JabbR.Services;
@@ -121,7 +122,7 @@ namespace JabbR.App_Start
             }
             catch (Exception ex)
             {
-                // ErrorSignal.Get(this).Raise(ex);
+                Elmah.ErrorLog.GetDefault(null).Log(new Error(ex));
             }
             finally
             {

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Turned on the setting to treat warnings as errors. Used the same
technique that WebBackgrounder does for logging unhandled exceptions
that aren't associated with a request.
