### PR TITLE
Added accesskeys for the chatroom tabs. Fixes #122.

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -114,16 +114,26 @@
 
 #tabs li {
     display: inline-block;
+    padding: 0;
     margin: 0px 4px 0px 0px;
-    font-weight: bold;
-    background-color: #164c85;
-    border-bottom: 0px;
-    color: #fff;
-    cursor: pointer;
     height: 30px;
+    border-bottom: 0px;
+    position: relative;
 }
 
-#tabs li.current {
+#tabs li button {
+    height: 100%;
+    margin: 0;
+    padding: 0 20px 0 0;
+    border: none;
+    outline: 0;
+    font-weight: bold;
+    background-color: #164c85;
+    color: #fff;
+    cursor: pointer;    
+}
+
+#tabs li.current button {
     color: #32aa52;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#f5f5f5', endColorstr='#e5e5e5'); /* for IE */
     background: -webkit-gradient(linear, left top, left bottom, from(#f5f5f5), to(#e5e5e5)); /* for webkit browsers */
@@ -136,19 +146,20 @@
 }
 
 #tabs li .close {
-    float: right;
-    margin: 8px 6px 6px 0px;
+    position: absolute;
+    top: 7px;
+    right: 5px;
 }
 
 #tabs li.unread {
 }
 
-#tabs li:hover {
+#tabs li button:hover {
     background-color: #e5e5e5;
     color: #32aa52;
 }
 
-#tabs li.current:hover {
+#tabs li.current button:hover {
     background-color: #e5e5e5;
 }
 

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -160,11 +160,14 @@
                   .appendTo($chatArea).hide();
 
         $tabs.find('li')
-             .not('.lobby')
-             .sortElements(function (a, b) {
-                 return $(a).data('name').toLowerCase() > $(b).data('name').toLowerCase() ? 1 : -1;
-             });
+            .not('.lobby')
+            .sortElements(function (a, b) {
+                return $(a).data('name').toLowerCase() > $(b).data('name').toLowerCase() ? 1 : -1;
+            });
 
+        $.each($tabs.find('li'), function (index, item) {
+            $(item).children('button:first-child').attr('accesskey', index);
+        });
         return true;
     }
 

--- a/JabbR/index.htm
+++ b/JabbR/index.htm
@@ -55,7 +55,9 @@
     </script>
     <script id="new-tab-template" type="text/x-jquery-tmpl">
         <li id="tabs-${id}" data-name="${name}">
-            <span class="content">${name}</span>
+            <button>
+                <span class="content">${name}</span>
+            </button>
             <img src="Content/images/close-icon.png" class="close" />
         </li>
     </script>
@@ -81,7 +83,7 @@
         </div>
         <ul id="tabs">
             <li id="tabs-lobby" class="current lobby" data-name="Lobby">
-                <span class="content">Lobby</span>
+                <button><span class="content">Lobby</span></button>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
I had to implement this using buttons rather than anchors. This blog post
on [browsers and html accesskeys](http://formattc.wordpress.com/2010/11/03/browsers-and-the-html-accesskey/)
explains why.

When using accesskeys on an anchor in IE, it doesn't produce a click
event like it does on other browsers. Using a button always produces
a click event.

`ALT+0` takes you to the lobby.
`ALT+1` takes you to the first room
...

On Firefox, it's `SHIFT+ALT+_RoomNumber_`

Also, on all browsers, `ALT+LeftArrow` and `ALT+RightArrow` lets you cycle
through the rooms.
