### PR TITLE
When removing a room, renumber the rooms access keys. Related to #122

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -149,6 +149,7 @@
     position: absolute;
     top: 7px;
     right: 5px;
+    cursor: pointer;
 }
 
 #tabs li.unread {

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -34,7 +34,7 @@
             return this.tab.hasClass('unread');
         };
 
-        this.updateUnread = function (isMentioned) {            
+        this.updateUnread = function (isMentioned) {
             var $tab = this.tab.addClass('unread'),
                 $content = $tab.find('.content'),
                 unread = ($tab.data('unread') || 0) + 1,
@@ -172,9 +172,7 @@
                 return $(a).data('name').toLowerCase() > $(b).data('name').toLowerCase() ? 1 : -1;
             });
 
-        $.each($tabs.find('li'), function (index, item) {
-            $(item).children('button:first-child').attr('accesskey', index);
-        });
+        setAccessKeys();
         return true;
     }
 
@@ -185,7 +183,14 @@
             room.tab.remove();
             room.messages.remove();
             room.users.remove();
+            setAccessKeys();
         }
+    }
+
+    function setAccessKeys() {
+        $.each($tabs.find('li'), function (index, item) {
+            $(item).children('button:first-child').attr('accesskey', index);
+        });
     }
 
     function navigateToRoom(roomName) {


### PR DESCRIPTION
When removing a room, accesskeys were left unchanged. So if you removed
room #2, ALT + 2 wouldn't do anything anymore. Makes more sense to renumber
the rooms.
