### PR TITLE
Add slideshare content provider

### DIFF
--- a/JabbR/ContentProviders/SlideshareContentProvider.cs
+++ b/JabbR/ContentProviders/SlideshareContentProvider.cs
@@ -14,16 +14,6 @@ namespace JabbR.ContentProviders
     /// </summary>
     public class SlideShareContentProvider : IContentProvider
     {
-
-        private static readonly string slideScript = string.Format(
-            "<div style='width:425px' id='__ss_10388027'> " +
-            "<strong style='display:block;margin:12px 0 4px'>" +
-            "<a href='{0}' target='_blank'></a></strong> " +
-           " <iframe src='http://www.slideshare.net/slideshow/embed_code/10388027' width='425' height='355' frameborder='0' marginwidth='0' marginheight='0' scrolling='no'></iframe> <div style='padding:5px 0 12px'> View more <a href='http://www.slideshare.net/' target='_blank'>presentations</a> from <a href='http://www.slideshare.net/verticalmeasures' target='_blank'>Vertical Measures</a> </div> </div>",
-           "test"
-
-            );
-
         private static readonly string oEmbedUrl = "http://www.slideshare.net/api/oembed/2?url={0}&format=json";
 
         public string GetContent(HttpWebResponse response)

--- a/JabbR/ContentProviders/SlideshareContentProvider.cs
+++ b/JabbR/ContentProviders/SlideshareContentProvider.cs
@@ -22,28 +22,19 @@ namespace JabbR.ContentProviders
             if (response.ResponseUri.AbsoluteUri.StartsWith("http://slideshare.net/", StringComparison.OrdinalIgnoreCase)
               || response.ResponseUri.AbsoluteUri.StartsWith("http://www.slideshare.net/", StringComparison.OrdinalIgnoreCase))
             {
-
-                try
+                // We have to make a call to the SlideShare api because
+                // their embed code request the unique ID of the slide deck
+                // where we will only have the url -- this call gets the json information
+                // on the slide deck and that package happens to already contain the embed code (.html)
+                HttpWebRequest webRequest = (HttpWebRequest)HttpWebRequest.Create(
+                        string.Format(oEmbedUrl, response.ResponseUri.AbsoluteUri));
+                WebResponse webResponse = webRequest.GetResponse();
+                using (var reader = new StreamReader(webResponse.GetResponseStream()))
                 {
-                    // We have to make a call to the SlideShare api because
-                    // their embed code request the unique ID of the slide deck
-                    // where we will only have the url -- this call gets the json information
-                    // on the slide deck and that package happens to already contain the embed code (.html)
-                    HttpWebRequest webRequest = (HttpWebRequest)HttpWebRequest.Create(
-                            string.Format(oEmbedUrl, response.ResponseUri.AbsoluteUri));
-                    WebResponse webResponse = webRequest.GetResponse();
-                    using (var reader = new StreamReader(webResponse.GetResponseStream()))
-                    {
-                        dynamic slideShareData = JsonConvert.DeserializeObject(reader.ReadToEnd()
-                                   );
-                        return slideShareData.html;
-                    }
+                    dynamic slideShareData = JsonConvert.DeserializeObject(reader.ReadToEnd()
+                               );
+                    return slideShareData.html;
                 }
-                catch (Exception ex)
-                {
-                    throw ex;
-                }
-
             }
             return null;
         }

--- a/JabbR/ContentProviders/SlideshareContentProvider.cs
+++ b/JabbR/ContentProviders/SlideshareContentProvider.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Web;
+using Newtonsoft.Json;
+
+namespace JabbR.ContentProviders
+{
+    /// <summary>
+    /// Content Provider that provides the necessary functionality to show SlideShare embed code in the chat when someone pastes a
+    /// slideshare link (eg. http://www.slideshare.net/verticalmeasures/search-social-and-content-marketing-move-your-business-forward-accelerate). 
+    /// Send feedback/issues to Seth Webster (@sethwebsterDanTup on Twitter).
+    /// </summary>
+    public class SlideShareContentProvider : IContentProvider
+    {
+
+        private static readonly string slideScript = string.Format(
+            "<div style='width:425px' id='__ss_10388027'> " +
+            "<strong style='display:block;margin:12px 0 4px'>" +
+            "<a href='{0}' target='_blank'></a></strong> " +
+           " <iframe src='http://www.slideshare.net/slideshow/embed_code/10388027' width='425' height='355' frameborder='0' marginwidth='0' marginheight='0' scrolling='no'></iframe> <div style='padding:5px 0 12px'> View more <a href='http://www.slideshare.net/' target='_blank'>presentations</a> from <a href='http://www.slideshare.net/verticalmeasures' target='_blank'>Vertical Measures</a> </div> </div>",
+           "test"
+
+            );
+
+        private static readonly string oEmbedUrl = "http://www.slideshare.net/api/oembed/2?url={0}&format=json";
+
+        public string GetContent(HttpWebResponse response)
+        {
+            if (response.ResponseUri.AbsoluteUri.StartsWith("http://slideshare.net/", StringComparison.OrdinalIgnoreCase)
+              || response.ResponseUri.AbsoluteUri.StartsWith("http://www.slideshare.net/", StringComparison.OrdinalIgnoreCase))
+            {
+                using (WebClient client = new WebClient())
+                {
+                    try
+                    {
+                        dynamic slideShareData = JsonConvert.DeserializeObject
+                                   (
+                                       client.DownloadString
+                                       (
+                                           string.Format(oEmbedUrl, response.ResponseUri.AbsoluteUri)
+                                       )
+                                   );
+                        return slideShareData.html;
+
+                    }
+                    catch (Exception ex)
+                    {
+                        throw ex;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/JabbR/ContentProviders/SlideshareContentProvider.cs
+++ b/JabbR/ContentProviders/SlideshareContentProvider.cs
@@ -15,7 +15,7 @@ namespace JabbR.ContentProviders
     /// </summary>
     public class SlideShareContentProvider : IContentProvider
     {
-        private static readonly string oEmbedUrl = "http://www.slideshare.net/api/oembed/2?url={0}&format=json";
+        private static readonly String oEmbedUrl = "http://www.slideshare.net/api/oembed/2?url={0}&format=json";
 
         public string GetContent(HttpWebResponse response)
         {
@@ -26,9 +26,9 @@ namespace JabbR.ContentProviders
                 // their embed code request the unique ID of the slide deck
                 // where we will only have the url -- this call gets the json information
                 // on the slide deck and that package happens to already contain the embed code (.html)
-                HttpWebRequest webRequest = (HttpWebRequest)HttpWebRequest.Create(
-                        string.Format(oEmbedUrl, response.ResponseUri.AbsoluteUri));
-                WebResponse webResponse = webRequest.GetResponse();
+                var webRequest = (HttpWebRequest)HttpWebRequest.Create(
+                        String.Format(oEmbedUrl, response.ResponseUri.AbsoluteUri));
+                var webResponse = webRequest.GetResponse();
                 using (var reader = new StreamReader(webResponse.GetResponseStream()))
                 {
                     dynamic slideShareData = JsonConvert.DeserializeObject(reader.ReadToEnd()

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -213,6 +213,7 @@
   <ItemGroup>
     <Compile Include="App_Start\Bootstrapper.cs" />
     <Compile Include="Commands\CommandManager.cs" />
+    <Compile Include="ContentProviders\SlideshareContentProvider.cs" />
     <Compile Include="ContentProviders\ResourceProcessor.cs" />
     <Compile Include="ContentProviders\GistContentProvider.cs" />
     <Compile Include="ContentProviders\IResourceProcessor.cs" />


### PR DESCRIPTION
Isolated changes; switched out WebClient for HttpWebRequest -- added some comments on why it's implemented as a separate request.

Basically, slidehsare's embed requires a unique id which comes from the oEmbedApi call.
