### PR TITLE
Css white underline fix.

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -175,6 +175,7 @@
 .note.message
 {
     background: url(Content/images/clippy.png) no-repeat;
+    border-bottom: none;
 }
 
 #tabs {


### PR DESCRIPTION
- Css fix which stops the white border underline from being displayed under the Note icon image. (The Afk icon image was not affected).
