### PR TITLE
Added url-transformation to private messages

### DIFF
--- a/JabbR.Test/CommandManagerFacts.cs
+++ b/JabbR.Test/CommandManagerFacts.cs
@@ -2252,6 +2252,37 @@ namespace JabbR.Test
                 Assert.True(result);
                 notificationService.Verify(x => x.SendPrivateMessage(user, user2, "what is up?"), Times.Once());
             }
+
+            [Fact]
+            public void UrlsInMessageIsTransformed()
+            {
+                var repository = new InMemoryRepository();
+                var user = new ChatUser
+                {
+                    Name = "dfowler",
+                    Id = "1"
+                };
+                repository.Add(user);
+                var user2 = new ChatUser
+                {
+                    Name = "dfowler2",
+                    Id = "2"
+                };
+                repository.Add(user2);
+                var service = new ChatService(repository, new Mock<ICryptoService>().Object);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("clientid",
+                                                        "1",
+                                                        null,
+                                                        service,
+                                                        repository,
+                                                        notificationService.Object);
+
+                bool result = commandManager.TryHandleCommand("/msg dfowler2 check out www.jabbr.net");
+
+                Assert.True(result);
+                notificationService.Verify(x => x.SendPrivateMessage(user, user2, "check out <a rel=\"nofollow external\" target=\"_blank\" href=\"http://www.jabbr.net\" title=\"www.jabbr.net\">www.jabbr.net</a>"), Times.Once());
+            }
         }
 
         public class NudgeCommand

--- a/JabbR.Test/TextTransformFacts.cs
+++ b/JabbR.Test/TextTransformFacts.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using JabbR.Infrastructure;
 using JabbR.Models;
 using Xunit;
@@ -47,7 +48,7 @@ namespace JabbR.Test
             }
 
             [Fact]
-            public void HashtagRegexMatchesHashtagInSubstring() 
+            public void HashtagRegexMatchesHashtagInSubstring()
             {
                 Regex hashtagRegex = HashtagRegex();
 
@@ -98,6 +99,51 @@ namespace JabbR.Test
                 string result = transform.Parse("#thisdoesnotexist");
 
                 Assert.Equal("#thisdoesnotexist", result);
+            }
+        }
+
+        public class ConvertUrlsToLinksFacts
+        {
+            [Fact]
+            public void UrlWithoutHttpIsTransformed()
+            {
+                //arrange
+                var message = "message www.jabbr.net continues on";
+                HashSet<string> extractedUrls;
+
+                //act
+                var result = TextTransform.TransformAndExtractUrls(message, out extractedUrls);
+
+                //assert
+                Assert.Equal("message <a rel=\"nofollow external\" target=\"_blank\" href=\"http://www.jabbr.net\" title=\"www.jabbr.net\">www.jabbr.net</a> continues on", result);
+            }
+
+            [Fact]
+            public void UrlWithHttpIsTransformed()
+            {
+                //arrange
+                var message = "message http://www.jabbr.net continues on";
+                HashSet<string> extractedUrls;
+
+                //act
+                var result = TextTransform.TransformAndExtractUrls(message, out extractedUrls);
+
+                //assert
+                Assert.Equal("message <a rel=\"nofollow external\" target=\"_blank\" href=\"http://www.jabbr.net\" title=\"http://www.jabbr.net\">http://www.jabbr.net</a> continues on", result);
+            }
+
+            [Fact]
+            public void UrlWithHttpsIsTransformed()
+            {
+                //arrange
+                var message = "message https://www.jabbr.net continues on";
+                HashSet<string> extractedUrls;
+
+                //act
+                var result = TextTransform.TransformAndExtractUrls(message, out extractedUrls);
+
+                //assert
+                Assert.Equal("message <a rel=\"nofollow external\" target=\"_blank\" href=\"https://www.jabbr.net\" title=\"https://www.jabbr.net\">https://www.jabbr.net</a> continues on", result);
             }
         }
     }

--- a/JabbR/Commands/CommandManager.cs
+++ b/JabbR/Commands/CommandManager.cs
@@ -521,8 +521,11 @@ namespace JabbR.Commands
                 throw new InvalidOperationException(String.Format("What did you want to say to '{0}'.", toUser.Name));
             }
 
+            HashSet<string> urls;
             var transform = new TextTransform(_repository);
             messageText = transform.Parse(messageText);
+
+            messageText = TextTransform.TransformAndExtractUrls(messageText, out urls);
 
             _notificationService.SendPrivateMessage(user, toUser, messageText);
         }

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -127,7 +127,7 @@ namespace JabbR
         {
             var textTransform = new TextTransform(_repository);
             string message = textTransform.Parse(content);
-            return Transform(message, out links);
+            return TextTransform.TransformAndExtractUrls(message, out links);
         }
 
         public void Disconnect()
@@ -752,32 +752,6 @@ namespace JabbR
 
             // Update the room count
             Clients.updateRoomCount(roomViewModel, room.Users.Online().Count());
-        }
-
-        private string Transform(string message, out HashSet<string> extractedUrls)
-        {
-            const string urlPattern = @"((https?|ftp)://|www\.)[\w]+(.[\w]+)([\w\-\.\[\],@?^=%&amp;:/~\+#!]*[\w\-\@?^=%&amp;/~\+#\[\]])";
-
-            var urls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            message = Regex.Replace(message, urlPattern, m =>
-            {
-                string httpPortion = String.Empty;
-                if (!m.Value.Contains("://"))
-                {
-                    httpPortion = "http://";
-                }
-
-                string url = httpPortion + m.Value;
-
-                urls.Add(HttpUtility.HtmlDecode(url));
-
-                return String.Format(CultureInfo.InvariantCulture,
-                                     "<a rel=\"nofollow external\" target=\"_blank\" href=\"{0}\" title=\"{1}\">{1}</a>",
-                                     url, m.Value);
-            });
-
-            extractedUrls = urls;
-            return message;
         }
 
         private ClientState GetClientState()

--- a/JabbR/Infrastructure/TextTransform.cs
+++ b/JabbR/Infrastructure/TextTransform.cs
@@ -42,6 +42,32 @@ namespace JabbR.Infrastructure
             return message;
         }
 
+        public static string TransformAndExtractUrls(string message, out HashSet<string> extractedUrls)
+        {
+            const string urlPattern = @"((https?|ftp)://|www\.)[\w]+(.[\w]+)([\w\-\.\[\],@?^=%&amp;:/~\+#!]*[\w\-\@?^=%&amp;/~\+#\[\]])";
+
+            var urls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            message = Regex.Replace(message, urlPattern, m =>
+            {
+                string httpPortion = String.Empty;
+                if (!m.Value.Contains("://"))
+                {
+                    httpPortion = "http://";
+                }
+
+                string url = httpPortion + m.Value;
+
+                urls.Add(HttpUtility.HtmlDecode(url));
+
+                return String.Format(CultureInfo.InvariantCulture,
+                                     "<a rel=\"nofollow external\" target=\"_blank\" href=\"{0}\" title=\"{1}\">{1}</a>",
+                                     url, m.Value);
+            });
+
+            extractedUrls = urls;
+            return message;
+        }
+
         private string ConvertHashtagsToRoomLinks(string message)
         {
             message = Regex.Replace(message, HashTagPattern, m =>


### PR DESCRIPTION
I was missing the ability to send urls in private messages when doing information about bot-commands in the jabbot and jibbr projects.

Since the url-transformation was a private method in the Chat-class I moved it to a static public method on TextTransform. I didn't implement the same kind of content extraction which is found in the chat-messages which means that the hashset of extracted urls are not used for anything in private messages.

I have added tests to verify that the messages are transformed when doing private messages aswell as verifying the functionality on a more granular level at the TextTransform.TransformAndExtractUrls method.
