### PR TITLE
Fix issue with git hub lssue links

### DIFF
--- a/JabbR/Chat.githubissues.js
+++ b/JabbR/Chat.githubissues.js
@@ -15,6 +15,9 @@
         // Process the template, and add it in to the div.
         $('#github-issues-template').tmpl(issue.data).appendTo(elements);
 
+        // After the string has been added to the template etc, remove any existing targets and re-add with _blank
+        $('a', elements).removeAttr('target').attr('target', '_blank');
+
         $('.js-relative-date').timeago();
         // If near the end, scroll.
         if (nearEnd) {

--- a/JabbR/Chat.utility.js
+++ b/JabbR/Chat.utility.js
@@ -55,9 +55,9 @@
     };
 
     // returns the date portion only (strips time)
-    Date.prototype.toDate = function () {
+    Date.prototype.toDate = function() {
         return new Date(this.getFullYear(), this.getMonth(), this.getDate());
-    }
+    };
 
     // returns difference (this - d) in days
     Date.prototype.diffDays = function (d) {


### PR DESCRIPTION
Git Hub Issues that contained links weren't opening in new Tab/Browser Window. 

Also added missing semicolon to JavaScript I noticed.
