### PR TITLE
Adding audio content provider

### DIFF
--- a/JabbR/ContentProviders/AudioContentProvider.cs
+++ b/JabbR/ContentProviders/AudioContentProvider.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using JabbR.ContentProviders.Core;
+
+namespace JabbR.ContentProviders
+{
+    public class AduioContentProvider : CollapsibleContentProvider
+    {
+        private static readonly HashSet<string> _audioMimeTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+            "audio/mpeg",
+            "audio/x-wav",
+            "aduio/ogg"
+        };
+
+        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        {
+            return new ContentProviderResultModel()
+             {
+                 Content = String.Format(@"<audio controls=""controls"" src=""{0}"">Your browser does not support the audio tag.</audio>", response.ResponseUri),
+                 Title = response.ResponseUri.AbsoluteUri.ToString()
+             };
+        }
+
+        protected override bool IsValidContent(HttpWebResponse response)
+        {
+            return !String.IsNullOrEmpty(response.ContentType) &&
+                    _audioMimeTypes.Contains(response.ContentType);
+
+        }
+    }
+}

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -249,6 +249,7 @@
     <Compile Include="Commands\CommandManager.cs" />
     <Compile Include="ContentProviders\BBCNewsContentProvider.cs" />
     <Compile Include="ContentProviders\BashQDBContentProvider.cs" />
+    <Compile Include="ContentProviders\AudioContentProvider.cs" />
     <Compile Include="ContentProviders\GitHubIssuesContentProvider.cs" />
     <Compile Include="ContentProviders\Core\CollapsibleContentProvider.cs" />
     <Compile Include="ContentProviders\Core\ContentProviderResultModel.cs" />


### PR DESCRIPTION
Adding an Audio provider that uses the audio tag. Will work for Audio/{mpeg|x-wav|ogg} mime types.
