### PR TITLE
github content provider: changed regex from digits to chars and digits

### DIFF
--- a/JabbR/ContentProviders/GistContentProvider.cs
+++ b/JabbR/ContentProviders/GistContentProvider.cs
@@ -7,7 +7,7 @@ namespace JabbR.ContentProviders
 {
     public class GistContentProvider : EmbedContentProvider
     {
-        private static readonly Regex _gistIdRegex = new Regex(@"(\d+)");
+        private static readonly Regex _gistIdRegex = new Regex(@"(\w+)");
 
         public override IEnumerable<string> Domains
         {


### PR DESCRIPTION
Problem with github content provider, f.e. https://gist.github.com/1cecc21e80ebc0658951
(fix untested, used edit & fork)
