### PR TITLE
Fixed GistContentProvider: my apologies

### DIFF
--- a/JabbR/ContentProviders/GistContentProvider.cs
+++ b/JabbR/ContentProviders/GistContentProvider.cs
@@ -7,7 +7,7 @@ namespace JabbR.ContentProviders
 {
     public class GistContentProvider : EmbedContentProvider
     {
-        private static readonly Regex _gistIdRegex = new Regex(@"(\w+)");
+        private static readonly Regex _gistIdRegex = new Regex(@"(\w+$)");
 
         public override IEnumerable<string> Domains
         {


### PR DESCRIPTION
Changed match from "(\w)" to "(\w$)" to make sure we only get the latest word match...

Resolves issue in pull request #323
Note to self: NEVER use fork & edit for code changes again... #MyApologies 
