### PR TITLE
Fix for issue #281

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -212,9 +212,9 @@
 
     function getRoomElements(roomName) {
         var roomId = getRoomId(roomName);
-        return new Room($('#tabs-' + roomId),
-                        $('#users-' + roomId),
-                        $('#messages-' + roomId));
+        return new Room($('[id="tabs-' + roomId + '"]'),
+                        $('[id="users-' + roomId + '"]'),
+                        $('[id="messages-' + roomId + '"]'));
     }
 
     function getCurrentRoomElements() {


### PR DESCRIPTION
The original issue reproduces with any room name with two "." in the name. JQuery seems to have trouble selecting id's with these in using the normal "#the.i.d" selector syntax: switching to the "[id="the.i.d"]" syntax works fine and fixes issue.
