### PR TITLE
Reducing the craziness in SoundCloud provider (don't Regex All the Things)

### DIFF
--- a/JabbR/ContentProviders/SoundCloudContentProvider.cs
+++ b/JabbR/ContentProviders/SoundCloudContentProvider.cs
@@ -1,42 +1,59 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using JabbR.ContentProviders.Core;
-using JabbR.Infrastructure;
+using Newtonsoft.Json;
 
 namespace JabbR.ContentProviders
 {
     public class SoundCloudContentProvider : CollapsibleContentProvider
     {
-        private static readonly Regex _titleRegex = new Regex("<meta.*content=\"(.*)\".*property=\"og:title\".*/>");
-        private static readonly Regex _trackIDExtractRegex = new Regex("<meta.*content=\"http://player\\.soundcloud\\.com/player\\.swf.*tracks%2F(.*?)&amp;.*property=\"og:video\"\\s*/>");
+        private sealed class SoundCloudResponse
+        {
+            [JsonProperty(PropertyName = "title")]
+            public string Title { get; set; }
+            [JsonProperty(PropertyName = "html")]
+            public string FrameMarkup { get; set; }
+        }
 
         protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
         {
-            using (var sr = new StreamReader(response.GetResponseStream()))
-            {
-                var pageContent = sr.ReadToEnd();
-                if (String.IsNullOrEmpty(pageContent))
-                {
-                    return null;
-                }
+            SoundCloudResponse widgetInfo = null;
 
-                var trackID = _trackIDExtractRegex.FindMatches(pageContent).SingleOrDefault();
-                var titleContent = _titleRegex.FindMatches(pageContent).SingleOrDefault();
+            var parentTask = new Task(
+                () =>
+                    {
+                        var webRequest =
+                            WebRequest.Create(
+                                string.Format(
+                                    @"http://soundcloud.com/oembed?format=json&iframe=true&show_comments=false&url={0}",
+                                    response.ResponseUri.AbsoluteUri));
 
-                if (trackID == null || titleContent == null)
-                {
-                    return null;
-                }
+                        var task = Task<WebResponse>.Factory.FromAsync(
+                            webRequest.BeginGetResponse, webRequest.EndGetResponse,
+                            TaskCreationOptions.AttachedToParent);
 
-                return new ContentProviderResultModel()
-                {
-                    Title = titleContent,
-                    Content = String.Format(@"<iframe width=""100%"" height=""166"" scrolling=""no"" frameborder=""no"" src=""http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F{0}&show_artwork=true&amp;autoplay=false&ampshow_comments=false&ampcolor=00103F""></iframe>", trackID)
-                };
-            }
+                        task.ContinueWith(
+                            tr =>
+                                {
+                                    using (var stream = tr.Result.GetResponseStream())
+                                    {
+                                        if (stream == null)
+                                            return;
+
+                                        using (var reader = new StreamReader(stream))
+                                        {
+                                            var json = reader.ReadToEnd();
+                                            widgetInfo = JsonConvert.DeserializeObject<SoundCloudResponse>(json);
+                                        }
+                                    }
+                                }, TaskContinuationOptions.AttachedToParent);
+                    });
+
+            parentTask.RunSynchronously();
+
+            return new ContentProviderResultModel {Title = widgetInfo.Title, Content = widgetInfo.FrameMarkup};
         }
 
         protected override bool IsValidContent(HttpWebResponse response)

--- a/JabbR/ContentProviders/SoundCloudContentProvider.cs
+++ b/JabbR/ContentProviders/SoundCloudContentProvider.cs
@@ -9,14 +9,6 @@ namespace JabbR.ContentProviders
 {
     public class SoundCloudContentProvider : CollapsibleContentProvider
     {
-        private sealed class SoundCloudResponse
-        {
-            [JsonProperty(PropertyName = "title")]
-            public string Title { get; set; }
-            [JsonProperty(PropertyName = "html")]
-            public string FrameMarkup { get; set; }
-        }
-
         protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
         {
             SoundCloudResponse widgetInfo = null;
@@ -40,7 +32,9 @@ namespace JabbR.ContentProviders
                                     using (var stream = tr.Result.GetResponseStream())
                                     {
                                         if (stream == null)
+                                        {
                                             return;
+                                        }
 
                                         using (var reader = new StreamReader(stream))
                                         {
@@ -53,12 +47,24 @@ namespace JabbR.ContentProviders
 
             parentTask.RunSynchronously();
 
-            return new ContentProviderResultModel {Title = widgetInfo.Title, Content = widgetInfo.FrameMarkup};
+            return new ContentProviderResultModel
+            {
+                Title = widgetInfo.Title,
+                Content = widgetInfo.FrameMarkup
+            };
         }
 
         protected override bool IsValidContent(HttpWebResponse response)
         {
             return response.ResponseUri.Host.IndexOf("soundcloud.com", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private sealed class SoundCloudResponse
+        {
+            [JsonProperty(PropertyName = "title")]
+            public string Title { get; set; }
+            [JsonProperty(PropertyName = "html")]
+            public string FrameMarkup { get; set; }
         }
     }
 }


### PR DESCRIPTION
Old Way:
1) Get permalink URL from user
2) Download the target HTML page
3) Grep for ID
4) Manually build iframe html

New Way:
1) Get permalink URL from user
2) Query SoundCloud's OEmbed Endpoint with that URL
3) Return Title and iframe code, nicely provided in JSON response from SoundCloud
4) Profit!
