### PR TITLE
Modify content providers so that they dont request pasted URLs unless they really need to

### DIFF
--- a/JabbR/ContentProviders/AudioContentProvider.cs
+++ b/JabbR/ContentProviders/AudioContentProvider.cs
@@ -13,21 +13,21 @@ namespace JabbR.ContentProviders
             "aduio/ogg"
         };
 
-        protected bool IsValidContent(HttpWebResponse response)
+        protected bool IsValidContent(Uri uri)
         {
-            return !String.IsNullOrEmpty(response.ContentType) &&
-                    _audioMimeTypes.Contains(response.ContentType);
+            return uri.AbsolutePath.EndsWith(".mp3", StringComparison.OrdinalIgnoreCase) || uri.AbsolutePath.EndsWith(".wav", StringComparison.OrdinalIgnoreCase) ||
+                   uri.AbsolutePath.EndsWith(".ogg", StringComparison.OrdinalIgnoreCase);
 
         }
 
-        public ContentProviderResultModel GetContent(HttpWebResponse response)
+        public ContentProviderResultModel GetContent(Uri uri)
         {
-            if (IsValidContent(response))
+            if (IsValidContent(uri))
             {
                 return new ContentProviderResultModel()
                 {
-                    Content = String.Format(@"<audio controls=""controls"" src=""{0}"">Your browser does not support the audio tag.</audio>", response.ResponseUri),
-                    Title = response.ResponseUri.AbsoluteUri.ToString()
+                    Content = String.Format(@"<audio controls=""controls"" src=""{0}"">Your browser does not support the audio tag.</audio>", uri),
+                    Title = uri.AbsoluteUri
                 };
             }
             return null;

--- a/JabbR/ContentProviders/BBCNewsContentProvider.cs
+++ b/JabbR/ContentProviders/BBCNewsContentProvider.cs
@@ -12,9 +12,9 @@ namespace JabbR.ContentProviders
     {
         private static readonly string ContentFormat = "<div class='bbc_wrapper'><div class=\"bbc_header\"><img src=\"/Content/images/contentproviders/bbcnews-masthead.png\" alt=\"\" width=\"84\" height=\"24\"></div><img src=\"{1}\" title=\"{2}\" alt=\"{3}\" class=\"bbc_newsimage\" /><h2>{0}</h2><div>{4}</div><div><a href=\"{5}\" target=\"_blank\">View article</a></div></div>";
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            var pageInfo = ExtractFromResponse(response);
+            var pageInfo = ExtractFromResponse(MakeRequest(uri));
             return new ContentProviderResultModel()
                        {
                            Content = String.Format(ContentFormat, pageInfo.Title, pageInfo.ImageURL, pageInfo.Title, pageInfo.Title, pageInfo.Description, pageInfo.PageURL),
@@ -59,9 +59,9 @@ namespace JabbR.ContentProviders
             public string PageURL { get; set; }
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.AbsoluteUri.StartsWith("http://www.bbc.co.uk/news", StringComparison.OrdinalIgnoreCase);
+            return uri.AbsoluteUri.StartsWith("http://www.bbc.co.uk/news", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JabbR/ContentProviders/BashQDBContentProvider.cs
+++ b/JabbR/ContentProviders/BashQDBContentProvider.cs
@@ -18,9 +18,9 @@ namespace JabbR.ContentProviders
 
         private static readonly string[] WhiteListHtml = new[] {"br", "#text"};
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            var pageInfo = ExtractFromResponse(response);
+            var pageInfo = ExtractFromResponse(MakeRequest(uri));
 
             if (pageInfo == null)
             {
@@ -88,12 +88,12 @@ namespace JabbR.ContentProviders
             public string QuoteNumber { get; set; }
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            var uri = response.ResponseUri.AbsoluteUri;
+            var x = uri.AbsolutePath;
 
-            return uri.StartsWith("http://www.bash.org/?", StringComparison.OrdinalIgnoreCase)
-                   || uri.StartsWith("http://bash.org/?", StringComparison.OrdinalIgnoreCase);
+            return x.StartsWith("http://www.bash.org/?", StringComparison.OrdinalIgnoreCase)
+                   || x.StartsWith("http://bash.org/?", StringComparison.OrdinalIgnoreCase);
 
         }
     }

--- a/JabbR/ContentProviders/Core/CollapsibleContentProvider.cs
+++ b/JabbR/ContentProviders/Core/CollapsibleContentProvider.cs
@@ -10,11 +10,11 @@ namespace JabbR.ContentProviders.Core
     public abstract class CollapsibleContentProvider : IContentProvider
     {
 
-        public virtual ContentProviderResultModel GetContent(HttpWebResponse response)
+        public virtual ContentProviderResultModel GetContent(Uri uri)
         {
-            if (IsValidContent(response))
+            if (IsValidContent(uri))
             {
-                var result = GetCollapsibleContent(response);
+                var result = GetCollapsibleContent(uri);
                 if (IsCollapsible && result != null)
                 {
                     result.Content = String.Format(CultureInfo.InvariantCulture,
@@ -38,6 +38,14 @@ namespace JabbR.ContentProviders.Core
             }
         }
 
+        protected virtual HttpWebResponse MakeRequest(Uri url)
+        {
+            const string _userAgent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; MAAU)";
+            var request = (HttpWebRequest)HttpWebRequest.Create(url);
+            request.UserAgent = _userAgent;
+            return (HttpWebResponse) request.GetResponse();
+        }
+
         protected virtual IList<string> ExtractParameters(Uri responseUri)
         {
             return ParameterExtractionRegex.Match(responseUri.AbsoluteUri)
@@ -48,9 +56,9 @@ namespace JabbR.ContentProviders.Core
                                 .Where(v => !String.IsNullOrEmpty(v)).ToList();     
 
         }
-        protected abstract ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response);
+        protected abstract ContentProviderResultModel GetCollapsibleContent(Uri uri);
 
-        protected abstract bool IsValidContent(HttpWebResponse response);
+        protected abstract bool IsValidContent(Uri uri);
 
         protected virtual bool IsCollapsible { get { return true; } }
         protected virtual bool IsPopOut { get { return true; } }

--- a/JabbR/ContentProviders/Core/EmbedContentProvider.cs
+++ b/JabbR/ContentProviders/Core/EmbedContentProvider.cs
@@ -11,9 +11,9 @@ namespace JabbR.ContentProviders.Core
         public abstract string MediaFormatString { get; }
 
        
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            var args = ExtractParameters(response.ResponseUri);
+            var args = ExtractParameters(uri);
             if (args == null || !args.Any())
             {
                 return null;
@@ -22,13 +22,13 @@ namespace JabbR.ContentProviders.Core
             return new ContentProviderResultModel()
             {
                 Content = String.Format(MediaFormatString, args.ToArray()),
-                Title = response.ResponseUri.AbsoluteUri.ToString()
+                Title = uri.AbsoluteUri
             };
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return Domains.Any(d => response.ResponseUri.AbsoluteUri.StartsWith(d, StringComparison.OrdinalIgnoreCase));
+            return Domains.Any(d => uri.AbsoluteUri.StartsWith(d, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/JabbR/ContentProviders/Core/IContentProvider.cs
+++ b/JabbR/ContentProviders/Core/IContentProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using System.Net;
 
 namespace JabbR.ContentProviders.Core
@@ -6,6 +7,6 @@ namespace JabbR.ContentProviders.Core
     [InheritedExport]
     public interface IContentProvider
     {
-        ContentProviderResultModel GetContent(HttpWebResponse response);
+        ContentProviderResultModel GetContent(Uri uri);
     }
 }

--- a/JabbR/ContentProviders/Core/ResourceProcessor.cs
+++ b/JabbR/ContentProviders/Core/ResourceProcessor.cs
@@ -10,19 +10,16 @@ namespace JabbR.ContentProviders.Core
     public class ResourceProcessor : IResourceProcessor
     {
         private readonly Lazy<IList<IContentProvider>> _contentProviders = new Lazy<IList<IContentProvider>>(GetContentProviders);
-        private const string _userAgent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; MAAU)";
 
         public Task<ContentProviderResultModel> ExtractResource(string url)
         {
-            var request = (HttpWebRequest)HttpWebRequest.Create(url);
-            request.UserAgent = _userAgent;
-            var requestTask = Task.Factory.FromAsync((cb, state) => request.BeginGetResponse(cb, state), ar => request.EndGetResponse(ar), null);
-            return requestTask.ContinueWith(task => ExtractContent((HttpWebResponse)task.Result));
+            var uri = new Uri(url);
+            return Task.Factory.StartNew(() => ExtractContent(uri));
         }
 
-        private ContentProviderResultModel ExtractContent(HttpWebResponse response)
+        private ContentProviderResultModel ExtractContent(Uri uri)
         {
-            return _contentProviders.Value.Select(c => c.GetContent(response))
+            return _contentProviders.Value.Select(c => c.GetContent(uri))
                                           .FirstOrDefault(content => content != null);
         }
 

--- a/JabbR/ContentProviders/DictionaryContentProvider.cs
+++ b/JabbR/ContentProviders/DictionaryContentProvider.cs
@@ -16,9 +16,9 @@ namespace JabbR.ContentProviders
                                                        "    <div>{1}</div>" +
                                                        "</div>";
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            var pageInfo = ExtractFromResponse(response);
+            var pageInfo = ExtractFromResponse(MakeRequest(uri));
             return new ContentProviderResultModel
             {
                 Content = String.Format(ContentFormat, pageInfo.Title, pageInfo.WordDefinition, pageInfo.ImageURL),
@@ -26,10 +26,10 @@ namespace JabbR.ContentProviders
             };
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.AbsoluteUri.StartsWith("http://dictionary.reference.com", StringComparison.OrdinalIgnoreCase) ||
-            response.ResponseUri.AbsoluteUri.StartsWith("http://dictionary.com", StringComparison.OrdinalIgnoreCase);
+            return uri.AbsoluteUri.StartsWith("http://dictionary.reference.com", StringComparison.OrdinalIgnoreCase) ||
+            uri.AbsoluteUri.StartsWith("http://dictionary.com", StringComparison.OrdinalIgnoreCase);
         }
 
         private PageInfo ExtractFromResponse(HttpWebResponse response)

--- a/JabbR/ContentProviders/GitHubIssuesContentProvider.cs
+++ b/JabbR/ContentProviders/GitHubIssuesContentProvider.cs
@@ -14,9 +14,9 @@ namespace JabbR.ContentProviders
         private static readonly string _gitHubIssuesApiFormat = "https://api.github.com/repos{0}/issues/{1}?callback=addGitHubIssue";
         private static readonly string _gitHubIssuesContentFormat = "<div class='git-hub-issue git-hub-issue-{0}'></div><script src='{1}'></script>";
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            var parameters = ExtractParameters(response.ResponseUri);
+            var parameters = ExtractParameters(uri);
 
             return new ContentProviderResultModel()
             {
@@ -24,22 +24,8 @@ namespace JabbR.ContentProviders
                         parameters[1],
                     String.Format(_gitHubIssuesApiFormat, parameters[0], parameters[1])
                 ),
-                Title = response.ResponseUri.AbsoluteUri
+                Title = uri.AbsoluteUri
             };
-        }
-
-        private static dynamic FetchIssue(string path)
-        {
-            var webRequest = (HttpWebRequest)WebRequest.Create(
-                String.Format(_gitHubIssuesApiFormat, path));
-            webRequest.Accept = "application/json";
-            using (var webResponse = webRequest.GetResponse())
-            {
-                using (var sr = new StreamReader(webResponse.GetResponseStream()))
-                {
-                    return JsonConvert.DeserializeObject(sr.ReadToEnd());
-                }
-            }
         }
 
         protected override Regex ParameterExtractionRegex
@@ -50,9 +36,9 @@ namespace JabbR.ContentProviders
             }
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return ExtractParameters(response.ResponseUri).Count == 2;
+            return ExtractParameters(uri).Count == 2;
         }
     }
 }

--- a/JabbR/ContentProviders/GoogleDocsPresentationsContentProvider.cs
+++ b/JabbR/ContentProviders/GoogleDocsPresentationsContentProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
@@ -35,16 +36,16 @@ namespace JabbR.ContentProviders
             }
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            if (!base.IsValidContent(response))
+            if (!base.IsValidContent(uri))
             {
                 // Someone may have pasted a link requiring a login --
                 // We can handle that here
-                if (response.ResponseUri.AbsoluteUri.StartsWith("https://accounts.google.com/ServiceLogin") ||
-                    response.ResponseUri.AbsoluteUri.StartsWith("http://accounts.google.com/ServiceLogin"))
+                if (uri.AbsoluteUri.StartsWith("https://accounts.google.com/ServiceLogin") ||
+                    uri.AbsoluteUri.StartsWith("http://accounts.google.com/ServiceLogin"))
                 {
-                    var qs = HttpUtility.ParseQueryString(response.ResponseUri.Query);
+                    var qs = HttpUtility.ParseQueryString(uri.Query);
                     if (qs.AllKeys.Contains("continue"))
                     {
                         return Domains.Any(d => qs["continue"].StartsWith(d));

--- a/JabbR/ContentProviders/GoogleMapsContentProvider.cs
+++ b/JabbR/ContentProviders/GoogleMapsContentProvider.cs
@@ -44,10 +44,10 @@ namespace JabbR.ContentProviders
         }
 
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            ContentProviderResultModel content = base.GetCollapsibleContent(response);
-            var queryString = HttpUtility.ParseQueryString(response.ResponseUri.Query);
+            ContentProviderResultModel content = base.GetCollapsibleContent(uri);
+            var queryString = HttpUtility.ParseQueryString(uri.Query);
             content.Title = queryString["q"] ?? "Google Maps";
             return content;
         }

--- a/JabbR/ContentProviders/ImageContentProvider.cs
+++ b/JabbR/ContentProviders/ImageContentProvider.cs
@@ -7,28 +7,23 @@ namespace JabbR.ContentProviders
 {
     public class ImageContentProvider : CollapsibleContentProvider
     {
-        private static readonly HashSet<string> _imageMimeTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
-            "image/png",
-            "image/jpg",
-            "image/jpeg",
-            "image/bmp",
-            "image/gif",
-        };
-
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
             return new ContentProviderResultModel()
              {
-                 Content = String.Format(@"<img src=""{0}"" />", response.ResponseUri),
-                 Title = response.ResponseUri.AbsoluteUri.ToString()
+                 Content = String.Format(@"<img src=""{0}"" />", uri),
+                 Title = uri.AbsoluteUri
              };
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return !String.IsNullOrEmpty(response.ContentType) &&
-                    _imageMimeTypes.Contains(response.ContentType);
-
+            string path = uri.AbsolutePath.ToLower();
+            return path.EndsWith(".png") ||
+                   path.EndsWith(".bmp") ||
+                   path.EndsWith(".jpg") ||
+                   path.EndsWith(".jpeg") ||
+                   path.EndsWith(".gif");
         }
     }
 }

--- a/JabbR/ContentProviders/ImgurContentProvider.cs
+++ b/JabbR/ContentProviders/ImgurContentProvider.cs
@@ -7,20 +7,20 @@ namespace JabbR.ContentProviders
 {
     public class ImgurContentProvider : CollapsibleContentProvider
     {        
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            string id = response.ResponseUri.AbsoluteUri.Split('/').Last();
+            string id = uri.AbsoluteUri.Split('/').Last();
 
             return new ContentProviderResultModel()
             {
                 Content = string.Format(@"<img src=""http://i.imgur.com/{0}.jpg"" />", id),
-                Title = response.ResponseUri.AbsoluteUri.ToString()
+                Title = uri.AbsoluteUri
             };
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.AbsoluteUri.StartsWith("http://imgur.com/", StringComparison.OrdinalIgnoreCase);
+            return uri.AbsoluteUri.StartsWith("http://imgur.com/", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JabbR/ContentProviders/JoinMeContentProvider.cs
+++ b/JabbR/ContentProviders/JoinMeContentProvider.cs
@@ -8,18 +8,18 @@ namespace JabbR.ContentProviders
     {
         private static readonly string _iframedMeetingFormat = "<iframe src=\"{0}\" width=\"700\" height=\"400\"></iframe>";
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
             return new ContentProviderResultModel()
             {
-                Content = String.Format(_iframedMeetingFormat, response.ResponseUri.AbsoluteUri),
-                Title = "Join Me Meeting: " + response.ResponseUri.AbsoluteUri.ToString()
+                Content = String.Format(_iframedMeetingFormat, uri.AbsoluteUri),
+                Title = "Join Me Meeting: " + uri.AbsoluteUri
             };
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.AbsoluteUri.StartsWith("https://join.me/", StringComparison.OrdinalIgnoreCase);
+            return uri.AbsoluteUri.StartsWith("https://join.me/", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JabbR/ContentProviders/NerdDinnerContentProvider.cs
+++ b/JabbR/ContentProviders/NerdDinnerContentProvider.cs
@@ -17,9 +17,9 @@ namespace JabbR.ContentProviders
         private static readonly string _nerdDinnerInfoContentFormat = "<h2>{0}</h2><p><strong>When: </strong>{1} @ {2}</p><p><strong>Where: </strong>{3}</p><p><strong>Description: </strong>{4}</p><p><div id='rsvpmsg'><strong>RSVP for this event:</strong><a href='http://nerddinner.com/RSVP/RsvpTwitterBegin/{5}'><img alt='Twitter' src='http://nerddinner.com/Content/Img/icon-twitter.png' border='0' style='padding:3px;' align='absmiddle'></a><a href='http://nerddinner.com/RSVP/RsvpBegin/{5}?identifier=https%3A%2F%2Fwww.google.com%2Faccounts%2Fo8%2Fid'><img alt='Google' src='http://nerddinner.com/Content/Img/icon-google.png' border='0'  style='padding:3px;' align='absmiddle'></a><a href='http://nerddinner.com/RSVP/RsvpBegin/{5}?identifier=https%3A%2F%2Fme.yahoo.com%2F'><img alt='Yahoo!' src='http://nerddinner.com/Content/Img/icon-yahoo.png' border='0'  style='padding:3px;' align='absmiddle'></a></p></div>";
         private static readonly string _nerdDinnerODdataFeedServiceDinnerQueryFormat = "http://nerddinner.com/Services/OData.svc/Dinners({0})";
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            string strDinnerId = ExtractParameter(response.ResponseUri);
+            string strDinnerId = ExtractParameter(uri);
             int dinnerId = 0;
             if (!String.IsNullOrEmpty(strDinnerId) && Int32.TryParse(strDinnerId, out dinnerId))
             {
@@ -73,12 +73,12 @@ namespace JabbR.ContentProviders
                                 .FirstOrDefault();
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.AbsoluteUri.StartsWith("http://nerddinner.com/", StringComparison.OrdinalIgnoreCase)
-               || response.ResponseUri.AbsoluteUri.StartsWith("http://www.nerddinner.com/", StringComparison.OrdinalIgnoreCase)
-               || response.ResponseUri.AbsoluteUri.StartsWith("http://nrddnr.com/", StringComparison.OrdinalIgnoreCase)
-               || response.ResponseUri.AbsoluteUri.StartsWith("http://www.nrddnr.com/", StringComparison.OrdinalIgnoreCase);
+            return uri.AbsoluteUri.StartsWith("http://nerddinner.com/", StringComparison.OrdinalIgnoreCase)
+               || uri.AbsoluteUri.StartsWith("http://www.nerddinner.com/", StringComparison.OrdinalIgnoreCase)
+               || uri.AbsoluteUri.StartsWith("http://nrddnr.com/", StringComparison.OrdinalIgnoreCase)
+               || uri.AbsoluteUri.StartsWith("http://www.nrddnr.com/", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JabbR/ContentProviders/NugetNuggetContentProvider.cs
+++ b/JabbR/ContentProviders/NugetNuggetContentProvider.cs
@@ -16,9 +16,9 @@ namespace JabbR.ContentProviders
         private static readonly string _nugetFeedURL = "http://packages.nuget.org/v1/FeedService.svc/Packages()?$filter=Id eq '{0}'&$orderby=Created desc";
         private static readonly string _nugetBadgeFormat = "<div class=\"nuget-badge\"><div class=\"nuget-pm\">PM></div><code>Install-Package {0}</code><div class=\"nuget-projectinfo\"><div class=\"nuget-title\">{1}</div><div class=\"nuget-summary\">{2}</div><div class=\"nuget-description\">{3}{4}</div>{5}<div style=\"clear:both\"></div></div></div>";
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            string packageName = ExtractPackageName(response.ResponseUri);
+            string packageName = ExtractPackageName(uri);
             if (!String.IsNullOrEmpty(packageName))
             {
                 dynamic package = FetchPackage(packageName);
@@ -85,11 +85,11 @@ namespace JabbR.ContentProviders
             return null;
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
             return
-                response.ResponseUri.AbsoluteUri.StartsWith("http://nuget.org", StringComparison.OrdinalIgnoreCase) ||
-                response.ResponseUri.AbsoluteUri.StartsWith("http://www.nuget.org", StringComparison.OrdinalIgnoreCase);
+                uri.AbsoluteUri.StartsWith("http://nuget.org", StringComparison.OrdinalIgnoreCase) ||
+                uri.AbsoluteUri.StartsWith("http://www.nuget.org", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JabbR/ContentProviders/SlideshareContentProvider.cs
+++ b/JabbR/ContentProviders/SlideshareContentProvider.cs
@@ -16,14 +16,14 @@ namespace JabbR.ContentProviders
         private static readonly String _oEmbedUrl = "http://www.slideshare.net/api/oembed/2?url={0}&format=json";
 
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
             // We have to make a call to the SlideShare api because
             // their embed code request the unique ID of the slide deck
             // where we will only have the url -- this call gets the json information
             // on the slide deck and that package happens to already contain the embed code (.html)
             var webRequest = (HttpWebRequest)HttpWebRequest.Create(
-                    String.Format(_oEmbedUrl, response.ResponseUri.AbsoluteUri));
+                    String.Format(_oEmbedUrl, uri.AbsoluteUri));
 
             using (var webResponse = webRequest.GetResponse())
             {
@@ -39,10 +39,10 @@ namespace JabbR.ContentProviders
             }
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.AbsoluteUri.StartsWith("http://slideshare.net/", StringComparison.OrdinalIgnoreCase)
-               || response.ResponseUri.AbsoluteUri.StartsWith("http://www.slideshare.net/", StringComparison.OrdinalIgnoreCase);
+            return uri.AbsoluteUri.StartsWith("http://slideshare.net/", StringComparison.OrdinalIgnoreCase)
+               || uri.AbsoluteUri.StartsWith("http://www.slideshare.net/", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JabbR/ContentProviders/SoundCloudContentProvider.cs
+++ b/JabbR/ContentProviders/SoundCloudContentProvider.cs
@@ -9,7 +9,7 @@ namespace JabbR.ContentProviders
 {
     public class SoundCloudContentProvider : CollapsibleContentProvider
     {
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
             SoundCloudResponse widgetInfo = null;
 
@@ -20,7 +20,7 @@ namespace JabbR.ContentProviders
                             WebRequest.Create(
                                 string.Format(
                                     @"http://soundcloud.com/oembed?format=json&iframe=true&show_comments=false&url={0}",
-                                    response.ResponseUri.AbsoluteUri));
+                                    uri.AbsoluteUri));
 
                         var task = Task<WebResponse>.Factory.FromAsync(
                             webRequest.BeginGetResponse, webRequest.EndGetResponse,
@@ -54,9 +54,9 @@ namespace JabbR.ContentProviders
             };
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.Host.IndexOf("soundcloud.com", StringComparison.OrdinalIgnoreCase) >= 0;
+            return uri.Host.IndexOf("soundcloud.com", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private sealed class SoundCloudResponse

--- a/JabbR/ContentProviders/TweetContentProvider.cs
+++ b/JabbR/ContentProviders/TweetContentProvider.cs
@@ -28,11 +28,11 @@ namespace JabbR.ContentProviders
             HttpUtility.HtmlEncode("http://api.twitter.com/1/statuses/show/{0}.json?include_entities=false&callback=addTweet")
         );
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
 
             // Extract the status id from the URL.
-            var status = _tweetRegex.Match(response.ResponseUri.AbsoluteUri)
+            var status = _tweetRegex.Match(uri.AbsoluteUri)
                                 .Groups
                                 .Cast<Group>()
                                 .Skip(1)
@@ -45,16 +45,16 @@ namespace JabbR.ContentProviders
                 return new ContentProviderResultModel()
                 {
                     Content = String.Format(tweetScript, status),
-                    Title = response.ResponseUri.AbsoluteUri
+                    Title = uri.AbsoluteUri
                 };
             }
             return null;
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.AbsoluteUri.StartsWith("http://twitter.com/", StringComparison.OrdinalIgnoreCase)
-                || response.ResponseUri.AbsoluteUri.StartsWith("https://twitter.com/", StringComparison.OrdinalIgnoreCase);
+            return uri.AbsoluteUri.StartsWith("http://twitter.com/", StringComparison.OrdinalIgnoreCase)
+                || uri.AbsoluteUri.StartsWith("https://twitter.com/", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JabbR/ContentProviders/TwitPicContentProvider.cs
+++ b/JabbR/ContentProviders/TwitPicContentProvider.cs
@@ -11,9 +11,9 @@ namespace JabbR.ContentProviders
 
         private readonly string _twitPicFormatString = @"<a href=""http://twitpic.com/{0}""> <img src=""http://twitpic.com/show/large/{0}""></a>";
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            var match = TwitPicUrlRegex.Match(response.ResponseUri.AbsoluteUri);
+            var match = TwitPicUrlRegex.Match(uri.AbsoluteUri);
 
             if (match.Success)
             {
@@ -21,15 +21,15 @@ namespace JabbR.ContentProviders
                 return new ContentProviderResultModel()
                 {
                     Content = String.Format(_twitPicFormatString, id),
-                    Title = response.ResponseUri.AbsoluteUri
+                    Title = uri.AbsoluteUri
                 };
             }
             return null;
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return TwitPicUrlRegex.IsMatch(response.ResponseUri.AbsoluteUri);
+            return TwitPicUrlRegex.IsMatch(uri.AbsoluteUri);
         }
     }
 }

--- a/JabbR/ContentProviders/UStreamContentProvider.cs
+++ b/JabbR/ContentProviders/UStreamContentProvider.cs
@@ -12,8 +12,9 @@ namespace JabbR.ContentProviders
     {
         private static readonly Regex _extractEmbedCodeRegex = new Regex(@"<textarea\s.*class=""embedCode"".*>(.*)</textarea>");
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
+            var response = MakeRequest(uri);
             var iframeHtml = HttpUtility.HtmlDecode(ExtractIFrameCode(response));
             return new ContentProviderResultModel()
             {
@@ -42,10 +43,10 @@ namespace JabbR.ContentProviders
             }
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.AbsoluteUri.StartsWith("http://ustream.tv/", StringComparison.OrdinalIgnoreCase)
-               || response.ResponseUri.AbsoluteUri.StartsWith("http://www.ustream.tv/", StringComparison.OrdinalIgnoreCase);
+            return uri.AbsoluteUri.StartsWith("http://ustream.tv/", StringComparison.OrdinalIgnoreCase)
+               || uri.AbsoluteUri.StartsWith("http://www.ustream.tv/", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/JabbR/ContentProviders/UserVoiceContentProvider.cs
+++ b/JabbR/ContentProviders/UserVoiceContentProvider.cs
@@ -10,9 +10,9 @@ namespace JabbR.ContentProviders
     {
         private static readonly string _uservoiceAPIURL = "http://{0}/api/v1/oembed.json?url={1}";
 
-        protected override ContentProviderResultModel GetCollapsibleContent(HttpWebResponse response)
+        protected override ContentProviderResultModel GetCollapsibleContent(Uri uri)
         {
-            var article = FetchArticle(response.ResponseUri);
+            var article = FetchArticle(uri);
             return new ContentProviderResultModel()
                        {
                            Title = article.title,
@@ -33,9 +33,9 @@ namespace JabbR.ContentProviders
             }
         }
 
-        protected override bool IsValidContent(HttpWebResponse response)
+        protected override bool IsValidContent(Uri uri)
         {
-            return response.ResponseUri.Host.IndexOf("uservoice.com", StringComparison.OrdinalIgnoreCase) >= 0;
+            return uri.Host.IndexOf("uservoice.com", StringComparison.OrdinalIgnoreCase) >= 0;
         }
     }
 }


### PR DESCRIPTION
I'm using these providers in my campfire web client. I realise its slightly different in JabbR because they are requested only once but in my client, the URLs are requested whenever somebody new joins the room or refreshes their page etc.

It seems very inefficient and a possible risk to blindly request every URL that is pasted in any channel.

I was speaking to dfowler about it the other night and he mentioned they might be being re-written to be client-side however this might be a useful interim measure.
