### PR TITLE
This will allow url's to contain ()

### DIFF
--- a/JabbR/Infrastructure/TextTransform.cs
+++ b/JabbR/Infrastructure/TextTransform.cs
@@ -44,7 +44,7 @@ namespace JabbR.Infrastructure
 
         public static string TransformAndExtractUrls(string message, out HashSet<string> extractedUrls)
         {
-            const string urlPattern = @"((https?|ftp)://|www\.)[\w]+(.[\w]+)([\w\-\.\[\],@?^=%&amp;:/~\+#!]*[\w\-\@?^=%&amp;/~\+#\[\]])";
+            const string urlPattern = @"(?i)(?<s>https?://|ftp://|mailto:|www.)?(?:\S+(?::\S*)?@)?(?:(?:[\w\p{S}][\w\p{S}@-]*[.:])+\w+)(?(s)/?|/)(?:(?:[^\s()<>.,\u0022'”]+|[.,\u0022'”][^\s()<>.,\u0022]|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))*)";
 
             var urls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             message = Regex.Replace(message, urlPattern, m =>


### PR DESCRIPTION
Changed the urlPattern regex to allow url's to contain a matching pair of parenthesis.  
Other changes include:
- Added mailto: addresses
- Previous code was case sensitive and would find http:// but not HTTP://
