### PR TITLE
Fixed error margin to prevent text overlapping timestamp

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -400,7 +400,7 @@ li.room:hover {
     padding: 5px;
 }
 
-.notification .content, .pm .content {
+.notification .content, .pm .content, .error .content {
     margin-right: 95px;
 }
 


### PR DESCRIPTION
For issue #402
