### PR TITLE
auto-hiding janrain modal on load and only displaying on ui.showLogin

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1444,10 +1444,12 @@
         showLogin: function () {
             if (janrain.ready === false) {
                 window.setTimeout(function () {
+                    $login.show();
                     janrain.engage.signin.modal.init();
                 }, 1000);
             }
             else {
+                $login.show();
                 janrain.engage.signin.modal.init();
             }
         },

--- a/JabbR/index.htm
+++ b/JabbR/index.htm
@@ -223,7 +223,7 @@
                 </li>
             </ul>
         </div>
-        <div id="janrainEngageEmbed">
+        <div id="janrainEngageEmbed" style="display: none;">
         </div>
         <div id="chat-area">
             <ul id="messages-lobby" class="messages current">


### PR DESCRIPTION
this fixes the second part of issue #421 (the issue posted by @ntulip).

It just hides the janrain engage modal by default and only shows it when the ui triggers the login modal to be displayed.

thanks to @johnsheehan for the fix :)
