### PR TITLE
add check to prevent trying to send any non-commands from within the lob...

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -542,7 +542,7 @@
             ui.addPrivateMessage('*' + from + '* has invited you to ' + roomLink + '. Click the room name to join.', 'pm');
         }
         else {
-            ui.addPrivateMessage('Invitation to *' + to + '* to join ' + roomLink  + ' has been sent.', 'pm');
+            ui.addPrivateMessage('Invitation to *' + to + '* to join ' + roomLink + ' has been sent.', 'pm');
         }
     };
 
@@ -692,6 +692,13 @@
 
 
         if (msg[0] !== '/') {
+
+            // if you're in the lobby, you can't send mesages (only commands)
+            if (chat.activeRoom === undefined) {
+                ui.addMessage("You cannot send messages within the Lobby", 'error');
+                return false;
+            }
+
             // Added the message to the ui first
             var viewModel = {
                 name: chat.name,

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -695,7 +695,7 @@
 
             // if you're in the lobby, you can't send mesages (only commands)
             if (chat.activeRoom === undefined) {
-                ui.addMessage("You cannot send messages within the Lobby", 'error');
+                ui.addMessage('You cannot send messages within the Lobby', 'error');
                 return false;
             }
 


### PR DESCRIPTION
...by

if the text is not a command while you're in the lobby then show an error. fixes issue #409
