### PR TITLE
Fix API generating URLs using private endpoint

### DIFF
--- a/JabbR.Tests/ApiFrontPageControllerFacts.cs
+++ b/JabbR.Tests/ApiFrontPageControllerFacts.cs
@@ -29,6 +29,7 @@ namespace JabbR.Test
                 ApiFrontPageController controller = new ApiFrontPageController(virtualPathMock.Object, appSettingsMock.Object);
                 var requestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/api");
                 requestMessage.Properties[HttpPropertyKeys.HttpConfigurationKey] = new HttpConfiguration();
+                requestMessage.SetIsLocal(true);
 
                 controller.Request = requestMessage;
 
@@ -49,6 +50,7 @@ namespace JabbR.Test
                 ApiFrontPageController controller = new ApiFrontPageController(virtualPathMock.Object, appSettingsMock.Object);
                 var requestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com/api");
                 requestMessage.Properties[HttpPropertyKeys.HttpConfigurationKey] = new HttpConfiguration();
+                requestMessage.SetIsLocal(true);
 
                 controller.Request = requestMessage;
 
@@ -56,6 +58,64 @@ namespace JabbR.Test
                 var responseData = controller.GetFrontPage().Content as ObjectContent;
 
                 Assert.Equal("theAppId", ((ApiFrontpageModel)responseData.Value).Auth.JanrainAppId);
+            }
+            [Fact]
+            public void ShouldUsePortWhenLocal()
+            {
+                Mock<IVirtualPathUtility> virtualPathMock = new Mock<IVirtualPathUtility>();
+                virtualPathMock.Setup(vp => vp.ToAbsolute(It.IsAny<string>())).Returns("/Auth/Login.ashx");
+
+                Mock<IApplicationSettings> appSettingsMock = new Mock<IApplicationSettings>();
+
+                ApiFrontPageController controller = new ApiFrontPageController(virtualPathMock.Object, appSettingsMock.Object);
+                var requestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com:1067/api");
+                requestMessage.Properties[HttpPropertyKeys.HttpConfigurationKey] = new HttpConfiguration();
+                requestMessage.SetIsLocal(true);
+
+                controller.Request = requestMessage;
+
+                var responseData = controller.GetFrontPage().Content as ObjectContent;
+
+                Assert.Equal("http://example.com:1067/Auth/Login.ashx", ((ApiFrontpageModel)responseData.Value).Auth.AuthUri);
+            }
+            [Fact]
+            public void ShouldUsePort80WhenNotLocal()
+            {
+                Mock<IVirtualPathUtility> virtualPathMock = new Mock<IVirtualPathUtility>();
+                virtualPathMock.Setup(vp => vp.ToAbsolute(It.IsAny<string>())).Returns("/Auth/Login.ashx");
+
+                Mock<IApplicationSettings> appSettingsMock = new Mock<IApplicationSettings>();
+
+                ApiFrontPageController controller = new ApiFrontPageController(virtualPathMock.Object, appSettingsMock.Object);
+                var requestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com:1067/api");
+                requestMessage.Properties[HttpPropertyKeys.HttpConfigurationKey] = new HttpConfiguration();
+                requestMessage.SetIsLocal(false);
+
+                controller.Request = requestMessage;
+
+                var responseData = controller.GetFrontPage().Content as ObjectContent;
+
+                Assert.Equal("http://example.com/Auth/Login.ashx", ((ApiFrontpageModel)responseData.Value).Auth.AuthUri);
+            }
+            [Fact]
+            public void ShouldUseHttpsWhenXForwardedProtoIsHttps()
+            {
+                Mock<IVirtualPathUtility> virtualPathMock = new Mock<IVirtualPathUtility>();
+                virtualPathMock.Setup(vp => vp.ToAbsolute(It.IsAny<string>())).Returns("/Auth/Login.ashx");
+
+                Mock<IApplicationSettings> appSettingsMock = new Mock<IApplicationSettings>();
+
+                ApiFrontPageController controller = new ApiFrontPageController(virtualPathMock.Object, appSettingsMock.Object);
+                var requestMessage = new HttpRequestMessage(HttpMethod.Get, "http://example.com:1067/api");
+                requestMessage.Properties[HttpPropertyKeys.HttpConfigurationKey] = new HttpConfiguration();
+                requestMessage.SetIsLocal(false);
+                requestMessage.Headers.Add("X-Forwarded-Proto", "https");
+
+                controller.Request = requestMessage;
+
+                var responseData = controller.GetFrontPage().Content as ObjectContent;
+
+                Assert.Equal("https://example.com/Auth/Login.ashx", ((ApiFrontpageModel)responseData.Value).Auth.AuthUri);
             }
         }
     }

--- a/JabbR/Infrastructure/HttpRequestExtensions.cs
+++ b/JabbR/Infrastructure/HttpRequestExtensions.cs
@@ -103,7 +103,8 @@ namespace JabbR.Infrastructure
         }
 
         /// <summary>
-        /// Determines whether the specified request is local. This seems like reverse engineering the actual implementation, so might change in future.
+        /// Determines whether the specified request is local. 
+        /// This seems like reverse engineering the actual implementation, so it might change in future.
         /// </summary>
         /// <param name="requestMessage">The request message.</param>
         /// <returns>
@@ -111,7 +112,8 @@ namespace JabbR.Infrastructure
         /// </returns>
         public static bool IsLocal(this HttpRequestMessage requestMessage)
         {
-            Lazy<bool> isLocal = requestMessage.Properties[HttpPropertyKeys.IsLocalKey] as Lazy<bool>;
+            //Web API sets IsLocal as a Lazy<bool> in the Properties dictionary
+            var isLocal = requestMessage.Properties[HttpPropertyKeys.IsLocalKey] as Lazy<bool>;
             if (isLocal != null)
             {
                 return isLocal.Value;
@@ -122,13 +124,14 @@ namespace JabbR.Infrastructure
 
 
         /// <summary>
-        /// Sets IsLocal into request message. This API seems unfinished, so for now we encapsulate the implementation details of dealing with IsLocal here.
-        /// This method should not be used outside of unit tests
+        /// Sets IsLocal for the specified HttpRequestMessage
+        /// Do not use outside of unit tests
         /// </summary>
         /// <param name="requestMessage">The request message.</param>
         /// <param name="value">New value of isLocal</param>
         public static void SetIsLocal(this HttpRequestMessage requestMessage, bool value)
         {
+            //Web API sets IsLocal as a Lazy<bool> in the Properties dictionary
             requestMessage.Properties[HttpPropertyKeys.IsLocalKey] = new Lazy<bool>(()=>value);
         }
 
@@ -141,7 +144,7 @@ namespace JabbR.Infrastructure
         /// <returns></returns>
         public static Uri GetAbsoluteUri(this HttpRequestMessage requestMessage, string relativeUri)
         {
-            string proto = "http";
+            var proto = "http";
             IEnumerable<string> headerValues;
 
             if (requestMessage.Headers.TryGetValues("X-Forwarded-Proto", out headerValues))

--- a/JabbR/WebApi/ApiFrontPageController.cs
+++ b/JabbR/WebApi/ApiFrontPageController.cs
@@ -27,10 +27,9 @@ namespace JabbR.WebApi
         /// <returns>A URL that corresponds to requested path using host and protocol of the request</returns>
         public string ToAbsoluteUrl(string sitePath)
         {
-            var requestUri = Request.RequestUri;
             var path = _VirtualPathUtilityWrapper.ToAbsolute(sitePath);
 
-            return requestUri.GetLeftPart(UriPartial.Authority) + path;
+            return Request.GetAbsoluteUri(path).AbsoluteUri;
         }
 
         public HttpResponseMessage GetFrontPage()


### PR DESCRIPTION
- Fix API generating links using host and port of that particular worker
  instance - i.e. when running behind AppHarbour Load Balancer.
- Add helper methods for getting and setting IsLocal flag on
  HttpRequestMessage.
