### PR TITLE
See what you're typing when new message line wraps

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -456,7 +456,7 @@ li.room
   width: 100%;
   height: 20px;
   resize: none;
-  overflow: hidden;
+  overflow: auto;
 }
 
 #send


### PR DESCRIPTION
When the new message line wraps, you can no longer see what you're typing. This allows you to see the line you're typing on.

Tested in IE9 on Windows and the latest stables of Chrome, Firefox, Safari on Windows 7 and OS X
