### PR TITLE
Slight fix for CSS alignment

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -523,7 +523,7 @@ li.room
   padding: 5px;
 }
 
-  .notification .content, .pm .content, .error .content
+  .notification .content, .pm .content, .error .content, .broadcast .content
   {
     margin-right: 95px;
   }


### PR DESCRIPTION
Broadcast announcements could end up trampling the timestamp; this stops them from doing so.
