### PR TITLE
Typing /r will expand to last private message source

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -576,6 +576,7 @@
         if (isSelf({ Name: to })) {
             // Force notification for direct messages
             ui.notify(true);
+            ui.setLastPrivate(from);
         }
 
         ui.addPrivateMessage('<emp>*' + from + '* &raquo; *' + to + '*</emp> ' + message, 'pm');

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -21,7 +21,7 @@
         templates = null,
         focus = true,
         commands = [],
-        Keys = { Up: 38, Down: 40, Esc: 27, Enter: 13, Slash: 47 },
+        Keys = { Up: 38, Down: 40, Esc: 27, Enter: 13, Slash: 47, Space: 32 },
         scrollTopThreshold = 75,
         toast = window.chat.toast,
         preferences = null,
@@ -33,7 +33,8 @@
         $document = $(document),
         $roomFilterInput = null,
         updateTimeout = 15000,
-        $richness = null;
+        $richness = null,
+        lastPrivate = null;
 
     function getRoomId(roomName) {
         return escape(roomName.toLowerCase()).replace(/[^a-z0-9]/, '_');
@@ -998,6 +999,12 @@
                         triggerSend();
                         ev.preventDefault();
                         return false;
+                    case Keys.Space:
+                        // Check for "/r " to reply to last private message
+                        if ($(this).val() === "/r" && lastPrivate) {
+                            ui.setMessage("/msg " + lastPrivate);
+                        }
+                        break;
                 }
             });
 
@@ -1650,6 +1657,9 @@
                  .find('.admin')
                  .text('');
             room.updateUserStatus($user);
+        },
+        setLastPrivate: function (userName) {
+            lastPrivate = userName;
         },
         shouldCollapseContent: shouldCollapseContent,
         collapseRichContent: collapseRichContent,


### PR DESCRIPTION
When you receive an incoming private message, the client will remember who sent the most recent one, and upon typing `/r` into the chat box, the text will expand into the form `/msg <username>` automatically filling in the username of the most recent person you have chatted with.
