### PR TITLE
Fix loading bug with rooms with numerical names

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -427,7 +427,7 @@
             closed: roomViewModel.Closed
         };
 
-        templates.tab.tmpl(viewModel).appendTo($tabs);
+        templates.tab.tmpl(viewModel).data('name', roomName).appendTo($tabs);
 
         $messages = $('<ul/>').attr('id', 'messages-' + roomId)
                               .addClass('messages')


### PR DESCRIPTION
If a room was named with only numeric characters, (e.g., "1"), then the various
.toLowerCase() calls would fail when the room name is retrieved. This is because
the "name" data field was never explicitly set, but rather it is inherited
through its "data-name" attribute. jQuery notes that it is a number and stores
it as such, so by explicitly storing it as a string, we can avoid these
problems.
