### PR TITLE
Fix to prevent message cycling from moving cursor

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -987,9 +987,11 @@
                 switch (key) {
                     case Keys.Up:
                         cycleMessage(ui.events.prevMessage);
+                        ev.preventDefault();
                         break;
                     case Keys.Down:
                         cycleMessage(ui.events.nextMessage);
+                        ev.preventDefault();
                         break;
                     case Keys.Esc:
                         $(this).val('');


### PR DESCRIPTION
Specifically for pressing the up arrow, after inserting the previous text in the
input box, the default action for up executes, which in Chrome is to move to the
beginning of the input box.
