### PR TITLE
Improvements to date headers in chat

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1363,8 +1363,8 @@
             // If our top message is a date header, it might be incorrect, so we
             // check to see if we should remove it so that it can be inserted
             // again at a more apropriate time.
-            if ($target.data('timestamp')) {
-                var postedDate = new Date($target.data('timestamp')).toDate();
+            if ($target.is(".list-header.date-header")) {
+                var postedDate = new Date($target.text()).toDate();
                 var lastPrependDate = messages[messages.length - 1].date.toDate();
 
                 if (!lastPrependDate.diffDays(postedDate)) {
@@ -1384,6 +1384,7 @@
 
                 if (this.date.toDate().diffDays(previousTimestamp.toDate())) {
                     ui.addMessageBeforeTarget(this.date.toLocaleDateString(), 'list-header', $target)
+                      .addClass('date-header')
                       .find('.right').remove(); // remove timestamp on date indicator
                 }
 
@@ -1443,6 +1444,7 @@
 
             if (message.date.toDate().diffDays(previousTimestamp.toDate())) {
                 ui.addMessage(message.date.toLocaleDateString(), 'list-header', roomName)
+                  .addClass('date-header')
                   .find('.right').remove(); // remove timestamp on date indicator
             }
 

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1352,12 +1352,25 @@
                 $previousMessage = null,
                 $current = null,
                 previousUser = null,
-                previousTimestamp = new Date();
+                previousTimestamp = new Date().addDays(1); // Tomorrow so we always see a date line
 
             if (messages.length === 0) {
                 // Mark this list as full
                 $messages.data('full', true);
                 return;
+            }
+
+            // If our top message is a date header, it might be incorrect, so we
+            // check to see if we should remove it so that it can be inserted
+            // again at a more apropriate time.
+            if ($target.data('timestamp')) {
+                var postedDate = new Date($target.data('timestamp')).toDate();
+                var lastPrependDate = messages[messages.length - 1].date.toDate();
+
+                if (!lastPrependDate.diffDays(postedDate)) {
+                    $target.remove();
+                    $target = $messages.children().first();
+                }
             }
 
             // Populate the old messages
@@ -1394,7 +1407,7 @@
             var room = getRoomElements(roomName),
                 $previousMessage = room.messages.children().last(),
                 previousUser = null,
-                previousTimestamp = new Date(),
+                previousTimestamp = new Date().addDays(1), // Tomorrow so we always see a date line
                 showUserName = true,
                 $message = null,
                 isMention = message.highlight;

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1363,7 +1363,7 @@
             // If our top message is a date header, it might be incorrect, so we
             // check to see if we should remove it so that it can be inserted
             // again at a more appropriate time.
-            if ($target.is(".list-header.date-header")) {
+            if ($target.is('.list-header.date-header')) {
                 var postedDate = new Date($target.text()).toDate();
                 var lastPrependDate = messages[messages.length - 1].date.toDate();
 
@@ -1407,8 +1407,8 @@
             // If our old top message is a message from the same user as the
             // last message in our prepended history, we can remove information
             // and continue
-            if ($target.is(".message") && $target.data('name') === $previousMessage.data('name')) {
-                $target.find(".left").children().not(".state").remove();
+            if ($target.is('.message') && $target.data('name') === $previousMessage.data('name')) {
+                $target.find('.left').children().not('.state').remove();
                 $previousMessage.addClass('continue');
             }
 
@@ -1417,7 +1417,7 @@
         },
         addChatMessage: function (message, roomName) {
             var room = getRoomElements(roomName),
-                $previousMessage = room.messages.children(".message").last(),
+                $previousMessage = room.messages.children('.message').last(),
                 previousUser = null,
                 previousTimestamp = new Date().addDays(1), // Tomorrow so we always see a date line
                 showUserName = true,

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1362,7 +1362,7 @@
 
             // If our top message is a date header, it might be incorrect, so we
             // check to see if we should remove it so that it can be inserted
-            // again at a more apropriate time.
+            // again at a more appropriate time.
             if ($target.is(".list-header.date-header")) {
                 var postedDate = new Date($target.text()).toDate();
                 var lastPrependDate = messages[messages.length - 1].date.toDate();
@@ -1386,6 +1386,9 @@
                     ui.addMessageBeforeTarget(this.date.toLocaleDateString(), 'list-header', $target)
                       .addClass('date-header')
                       .find('.right').remove(); // remove timestamp on date indicator
+
+                    // Force a user name to show after the header
+                    previousUser = null;
                 }
 
                 // Determine if we need to show the user
@@ -1400,6 +1403,14 @@
 
                 $previousMessage = $('#m-' + this.id);
             });
+
+            // If our old top message is a message from the same user as the
+            // last message in our prepended history, we can remove information
+            // and continue
+            if ($target.is(".message") && $target.data('name') === $previousMessage.data('name')) {
+                $target.find(".left").children().not(".state").remove();
+                $previousMessage.addClass('continue');
+            }
 
             // Scroll to the bottom element so the user sees there's more messages
             $target[0].scrollIntoView();
@@ -1423,6 +1434,16 @@
                 previousTimestamp = new Date($previousMessage.data('timestamp') || new Date());
             }
 
+            // Determine if we need to show a new date header
+            if (message.date.toDate().diffDays(previousTimestamp.toDate())) {
+                ui.addMessage(message.date.toLocaleDateString(), 'list-header', roomName)
+                  .addClass('date-header')
+                  .find('.right').remove(); // remove timestamp on date indicator
+
+                // Force a user name to show after the header
+                previousUser = null;
+            }
+
             // Determine if we need to show the user name next to the message
             showUserName = previousUser !== message.name;
             message.showUser = showUserName;
@@ -1440,12 +1461,6 @@
                     room.removeSeparator();
                 }
                 room.addSeparator();
-            }
-
-            if (message.date.toDate().diffDays(previousTimestamp.toDate())) {
-                ui.addMessage(message.date.toLocaleDateString(), 'list-header', roomName)
-                  .addClass('date-header')
-                  .find('.right').remove(); // remove timestamp on date indicator
             }
 
             templates.message.tmpl(message).appendTo(room.messages);

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1405,7 +1405,7 @@
         },
         addChatMessage: function (message, roomName) {
             var room = getRoomElements(roomName),
-                $previousMessage = room.messages.children().last(),
+                $previousMessage = room.messages.children(".message").last(),
                 previousUser = null,
                 previousTimestamp = new Date().addDays(1), // Tomorrow so we always see a date line
                 showUserName = true,

--- a/JabbR/Chat.utility.js
+++ b/JabbR/Chat.utility.js
@@ -94,6 +94,11 @@
         return parseInt((t1 - t2) / (24 * 3600 * 1000));
     };
 
+    // adds a certain number of days to a Date object
+    Date.prototype.addDays = function (days) {
+        return new Date(this.getTime() + 1000 * 3600 * 24 * days);
+    }
+
     var utility = {
         trim: function (value, length) {
             if (value.length > length) {


### PR DESCRIPTION
Some things I did:
- Fixed a bug where date header would sometimes not appear if you were in chat at the time of the day rollover
- Fixed an oddity where pulling in more history did not reset the date header at the top, which meant it would be left in between two messages of the same time
- Always show a date header at the very top
- User names always show next to messages after a date header
- The user name of the top message is removed during scrollback if the previous message was also by said user
