### PR TITLE
Fix to up/down arrow keys in multiline messages

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -988,12 +988,14 @@
                 var key = ev.keyCode || ev.which;
                 switch (key) {
                     case Keys.Up:
-                        cycleMessage(ui.events.prevMessage);
-                        ev.preventDefault();
+                        if (cycleMessage(ui.events.prevMessage)) {
+                            ev.preventDefault();
+                        }
                         break;
                     case Keys.Down:
-                        cycleMessage(ui.events.nextMessage);
-                        ev.preventDefault();
+                        if (cycleMessage(ui.events.nextMessage)) {
+                            ev.preventDefault();
+                        }
                         break;
                     case Keys.Esc:
                         $(this).val('');
@@ -1011,11 +1013,14 @@
                 }
             });
 
+            // Returns true if a cycle was triggered
             function cycleMessage(messageHistoryDirection) {
                 var currentMessage = $newMessage[0].value;
                 if (currentMessage.length === 0 || lastCycledMessage === currentMessage) {
                     $ui.trigger(messageHistoryDirection);
+                    return true;
                 }
+                return false;
             }
 
             // Auto-complete for user names


### PR DESCRIPTION
See #538 for my commit that was merged in that introduced this bug.

Previously we prevented the default event to stop the cursor from moving when we
cycle through messages, but that unintendedly prevents us from scrolling around
after pasting in a multi-line message. We can return whether a cycle took place
to know whether we should stop the key from moving the cursor.
