### PR TITLE
Fix a scrolling bug reproducible in Chrome stable

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -154,7 +154,11 @@
         };
 
         this.scrollToBottom = function () {
-            this.messages.scrollTop(this.messages[0].scrollHeight);
+            var height = this.messages[0].scrollHeight - this.messages.height();
+
+            this.messages
+                .scrollTop(height - 1) // Fix for bug in Chrome
+                .scrollTop(height);
         };
 
         this.isNearTheEnd = function () {


### PR DESCRIPTION
When a scrollable element is hidden and re-shown, as tabs are in the case of
JabbR, it appears that the internal position is maintained, but upon attempting
to scroll, the scroll bar will jump to the top. In JabbR, scrollToBottom is
always called when tabs are changed; however, when the scrollTop is set to its
current value, nothing changes internally. This means that if the user was at
the bottom of the scroll when switching tabs, upon switching back and scrolling
down, the chat will jump to the top.

Additionally, the scrollTop value was set to the scrollHeight of the element,
which is not the proper scrollTop, since you must subtract the height of the
actual element itself. This is normally not a problem, since the browser will
create an upper bound, but in this fix, subtracting 1 will still make it bounded
by the correct value and thus not actually change the scroll value which is
necessary to workaround the bug.
