### PR TITLE
Improve the automatic scrolling for rich content

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1224,6 +1224,33 @@
                 room.scrollToBottom();
             }
         },
+        watchMessageScroll: function (messageIds, roomName) {
+            // Given an array of message ids, if there is any embedded content
+            // in it, it may cause the window to scroll off of the bottom, so we
+            // can watch for that and correct it.
+            messageIds = $.map(messageIds, function (id) { return '#m-' + id; });
+
+            var $messages = $(messageIds.join(',')),
+                $content = $messages.expandableContent(),
+                room = getRoomElements(roomName),
+                nearTheEndBefore = room.messages.isNearTheEnd(),
+                scrollTopBefore = room.messages.scrollTop();
+
+            if (nearTheEndBefore && $content.length > 0) {
+                // Note that the load event does not bubble, so .on() is not
+                // suitable here.
+                $content.load(function () {
+                    // If we used to be at the end and our scrollTop() did not
+                    // change, then we can safely call scrollToBottom() without
+                    // worrying about interrupting the user. We skip this if the
+                    // room is already at the end in the event of multiple
+                    // images loading at the same time.
+                    if (!room.messages.isNearTheEnd() && scrollTopBefore === room.messages.scrollTop()) {
+                        room.scrollToBottom();
+                    }
+                });
+            }
+        },
         isNearTheEnd: function (roomName) {
             var room = roomName ? getRoomElements(roomName) : getCurrentRoomElements();
 

--- a/JabbR/Chat.utility.js
+++ b/JabbR/Chat.utility.js
@@ -32,6 +32,14 @@
         return this[0].scrollTop + this.height() >= this[0].scrollHeight;
     };
 
+    $.fn.expandableContent = function () {
+        // These are selectors to various rich content that may increase the
+        // scrollable area after they were initially appended
+        var selectors = ['img'];
+
+        return this.find(selectors.join(','));
+    };
+
     // REVIEW: is it safe to assume we do not need to strip tags before decoding?
     function decodeHtml(html) {
         // should we strip tags before running this?


### PR DESCRIPTION
Three notable instances were corrected here:
- When someone enters an image link, once that image loads the window may scroll
  up past the bottom edge of the screen.
- When you join a room with images, as they load they will push the scroll up.
- When you paste content, it is later replaced with the full version from the
  server, which causes chat to be scrolled up.

The latter of the three was the most simple case, and it involved simply placing
the ui.replaceMessage() function into the scrollIfNecessary wrapper.

In the case of the images, there was already a system in place to force scroll
after 850ms in the case of a new message; however, this was not working since it
required you to already be at the end of the chat scroll. A new method was added
that can be called to attach load event handlers to elements within those
messages which will correct the scroll position only if the user himself has not
touched it in the meantime.

Deciding which elements to attach the load event handler to is done in the
utility function expandableContent(), which uses a hard-coded list of selectors
to search for within the messages provided. Most rich content in JabbR has
hard-coded dimensions, but the one exception that I found in my testing was
images for obvious reasons. If there are more, they can be easily added to the
array. At the very least, the functionality will not regress as it was never
working in the first place.
