### PR TITLE
Minor fix to click-to-message functionality

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -877,7 +877,7 @@
 
                 // If it was a message to another person, replace that
                 if (message.indexOf('/msg') === 0) {
-                    message = message.replace(/^\/msg \S+ /, '');
+                    message = message.replace(/^\/msg \S+/, '');
                 }
 
                 // Re-focus because we lost it on the click


### PR DESCRIPTION
When the .trim() was added to the message, I did not consider that a space is
added initially when you click a name. The only functionality this fixes is if
you click a name and then try to click another without typing anything. While it
isn't a big deal, it's also not a big fix.

Sorry!
