### PR TITLE
Various scroll fixes

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -79,9 +79,12 @@
                     // that are added after initial population
                     ui.setInitialized(room);
                     ui.scrollToBottom(room);
-                    ui.watchMessageScroll(messageIds, room);
 
                     d.resolveWith(chat);
+
+                    // Watch the messages after the defer, since room messages
+                    // may be appended if we are just joining the room
+                    ui.watchMessageScroll(messageIds, room);
                 })
                 .fail(function () {
                     d.rejectWith(chat);

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -486,8 +486,11 @@
                 return;
             }
 
-            // If you're we're near the top, raise the event
-            if ($(this).scrollTop() <= scrollTopThreshold) {
+            // If you're we're near the top, raise the event, but if the scroll
+            // bar is small enough that we're at the bottom edge, ignore it.
+            // We have to use the ui version because the room object above is
+            // not fully initialized, so there are no messages.
+            if ($(this).scrollTop() <= scrollTopThreshold && !ui.isNearTheEnd(roomId)) {
                 var $child = $messages.children('.message:first');
                 if ($child.length > 0) {
                     messageId = $child.attr('id')

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1254,6 +1254,10 @@
                     // images loading at the same time.
                     if (!room.messages.isNearTheEnd() && scrollTopBefore === room.messages.scrollTop()) {
                         room.scrollToBottom();
+                        // Reset our scrollTopBefore so we know we are allowed
+                        // to move it again if another image loads and the user
+                        // hasn't touched it
+                        scrollTopBefore = room.messages.scrollTop();
                     }
 
                     // unbind the event from this object after it executes

--- a/JabbR/Chat.utility.js
+++ b/JabbR/Chat.utility.js
@@ -35,7 +35,7 @@
     $.fn.expandableContent = function () {
         // These are selectors to various rich content that may increase the
         // scrollable area after they were initially appended
-        var selectors = ['img'];
+        var selectors = ['img:not(.gravatar)'];
 
         return this.find(selectors.join(','));
     };


### PR DESCRIPTION
These are mostly in follow up to #556.
1. I had encountered a situation where a room I was in loaded enough messages to fill barely more than the height of the chat window, so it thought I was passed the threshold before I even tried to scroll. Remedied this by not loading scrollback if you are scrolled to the end.
2. Minor performance change; I was originally attaching load events to all the gravatars, which is unnecessary.
3. This was a bit of a challenge since it was not reproducible when stepping through the debugger, but it turns out that the chat messages are changed after the deferred is resolved, which is immediately after we record the scrollHeight to see if the user tried to move it. I fixed this by attaching the load listeners _after_ the deferred is resolved, but I don't know if this is poor practice or not, as I have not used jQuery's deferreds much. Let me know what you think.
