### PR TITLE
Allow javascript and css to be delivered unminified in debug mode

### DIFF
--- a/JabbR/default.aspx
+++ b/JabbR/default.aspx
@@ -23,7 +23,6 @@
                   "~/Content/KeyTips.css",
                   "~/Content/bootstrap.min.css",
                   "~/Content/emoji20.css")
-            .ForceRelease()
             .Render("~/Content/JabbR_#.css")
   %>
 
@@ -306,7 +305,6 @@
         "~/Scripts/jquery.KeyTips.js",
         "~/Scripts/jquery-ui-1.8.17.min.js",
         "~/Scripts/jquery.signalR-0.5.2.min.js")
-            .ForceRelease()
             .Render("~/Scripts/JabbR1_#.js")
   %>
   <script type="text/javascript" src='<%= ResolveClientUrl("~/signalr/hubs") %>'></script>
@@ -330,7 +328,6 @@
         "~/Chat.pinnedWindows.js",
         "~/Chat.githubissues.js",
         "~/Chat.js")
-            .ForceRelease()
             .Render("~/Scripts/JabbR2_#.js")
   %>
 </body>


### PR DESCRIPTION
I keep making this change locally, since it is nearly impossible to debug
JavaScript when it is minified. By not calling ForceRelease(), SquishIt will
only minify when a release is built.
