### PR TITLE
Fix scrollToBottom when a horizontal scrollbar is present

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -162,11 +162,9 @@
         };
 
         this.scrollToBottom = function () {
-            var height = this.messages[0].scrollHeight - this.messages.height();
-
             this.messages
-                .scrollTop(height - 1) // Fix for bug in Chrome
-                .scrollTop(height);
+                .scrollTop(0) // Fix for bug in Chrome
+                .scrollTop(this.messages[0].scrollHeight);
         };
 
         this.isNearTheEnd = function () {


### PR DESCRIPTION
Because the scrollHeight - height calculations do not give the actual max scroll
value, we have reverted to using just scrollHeight, which is an obvious
overshoot. That said, the only reason it was changed originally was so that the
scroll fix for chrome could offset it by 1 and then back again, but this can be
worked around by setting it to 0. Because the browser won't repaint immediately,
no stutter should be visible.
