### PR TITLE
Fix double-encoding of URLs, causing valid URLs to break and invalid ones to be turned into links

### DIFF
--- a/JabbR.Tests/TextTransformFacts.cs
+++ b/JabbR.Tests/TextTransformFacts.cs
@@ -237,6 +237,34 @@ namespace JabbR.Test
             }
 
             [Fact]
+            public void UrlWithAmpersand()
+            {
+                //arrange
+                var message = "message http://google.com/?1&amp;2 continues on";
+                HashSet<string> extractedUrls;
+
+                //act
+                var result = TextTransform.TransformAndExtractUrls(message, out extractedUrls);
+
+                //assert
+                Assert.Equal("message <a rel=\"nofollow external\" target=\"_blank\" href=\"http://google.com/?1&amp;2\" title=\"http://google.com/?1&amp;2\">http://google.com/?1&amp;2</a> continues on", result);
+            }
+
+            [Fact]
+            public void UrlWithInvalidButEscapedCharacters()
+            {
+                //arrange
+                var message = "message http://google.com/&lt;a&gt; continues on";
+                HashSet<string> extractedUrls;
+
+                //act
+                var result = TextTransform.TransformAndExtractUrls(message, out extractedUrls);
+
+                //assert
+                Assert.Equal("message http://google.com/&lt;a&gt; continues on", result);
+            }
+
+            [Fact]
             public void LocalHost()
             {
                 //arrange

--- a/JabbR/Infrastructure/TextTransform.cs
+++ b/JabbR/Infrastructure/TextTransform.cs
@@ -50,7 +50,7 @@ namespace JabbR.Infrastructure
             var urls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             message = urlPattern.Replace(message, m =>
             {
-                string url = m.Value;
+                string url = HttpUtility.HtmlDecode(m.Value);
                 if (!url.Contains("://"))
                 {
                     url = "http://" + url;
@@ -61,7 +61,7 @@ namespace JabbR.Infrastructure
                     return m.Value;
                 }
 
-                urls.Add(HttpUtility.HtmlDecode(url));
+                urls.Add(url);
 
                 return String.Format(CultureInfo.InvariantCulture,
                                      "<a rel=\"nofollow external\" target=\"_blank\" href=\"{0}\" title=\"{1}\">{1}</a>",


### PR DESCRIPTION
Since message is HTML-encoded when passed into TransformAndExtractUrls, HTML-decode the matched URLs before checking their validity or attribute-encoding them
