### PR TITLE
Announce topic changes to everyone in room as notification

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -516,10 +516,15 @@
         ui.changeRoomTopic(room);
     };
 
-    chat.topicChanged = function (isCleared, topic) {
+    chat.topicChanged = function (isCleared, topic, who) {
         var action = isCleared ? 'cleared' : 'set';
         var to = topic ? ' to ' + '"' + topic + '"' : '';
-        var message = 'You have ' + action + ' the room topic' + to;
+        var message = action + ' the room topic' + to;
+        if (who === ui.getUserName()) {
+            message = 'You have ' + message;
+        } else {
+            message = who + ' has ' + message;
+        }
         ui.addMessage(message, 'notification', this.activeRoom);
     };
 

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -896,10 +896,7 @@ namespace JabbR
         {
             bool isTopicCleared = String.IsNullOrWhiteSpace(room.Topic);
             var parsedTopic = ConvertUrlsAndRoomLinks(room.Topic ?? "");
-            foreach (var client in user.ConnectedClients)
-            {
-                Clients[client.Id].topicChanged(isTopicCleared, parsedTopic);
-            }
+            Clients[room.Name].topicChanged(isTopicCleared, parsedTopic, user.Name);
             // Create the view model
             var roomViewModel = new RoomViewModel
             {


### PR DESCRIPTION
This seems to be a pretty common thing in chat clients, so I thought it would also make sense here. Preview:

![Topic Announcements](https://trello-attachments.s3.amazonaws.com/4fdbaf52e902d4c23d0b0a0d/500bc42fcad9b1ed74203b3b/5cbeca7380484d56caa02d72a9ed442d/upload_2012-08-11_at_6.49.45_pm.png)
