### PR TITLE
Fix webkit scrolling bug again in newer versions

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -180,7 +180,7 @@
             // IE will repaint if we do the Chrome bugfix and look jumpy
             if ($.browser.webkit) {
                 // Chrome fix for hiding and showing scroll areas
-                this.messages.scrollTop(0);
+                this.messages.scrollTop(this.messages.scrollTop() - 1);
             }
             this.messages.scrollTop(this.messages[0].scrollHeight);
         };


### PR DESCRIPTION
In newer versions of Chrome and Safari, particularly on OSX, the scrolling bug
returns and seems to be impervious to the previous hack. In this case, it
ignores the scrollTop when it is 0 despite the fact that the scrollbar is at the
bottom. To get around this, we just jiggle the scroll height by 1.

Also note: this still works for Windows Chrome 21.
