### PR TITLE
Fixing dual scroll bars on the help dialog

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -2220,6 +2220,7 @@ li.clearfix
 {
     overflow: auto;
     margin: 0 0 0 10px;
+    max-height: 430px;
 } 
 
 .command-list


### PR DESCRIPTION
Setting max-height on the help-body fixes the dual scroll bar issue
