### PR TITLE
Bug fix for topic announcements in rooms that are not active

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -516,7 +516,7 @@
         ui.changeRoomTopic(room);
     };
 
-    chat.topicChanged = function (isCleared, topic, who) {
+    chat.topicChanged = function (roomName, isCleared, topic, who) {
         var action = isCleared ? 'cleared' : 'set';
         var to = topic ? ' to ' + '"' + topic + '"' : '';
         var message = action + ' the room topic' + to;
@@ -525,7 +525,7 @@
         } else {
             message = who + ' has ' + message;
         }
-        ui.addMessage(message, 'notification', this.activeRoom);
+        ui.addMessage(message, 'notification', roomName);
     };
 
     chat.welcomeChanged = function (isCleared, welcome) {

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -901,7 +901,7 @@ namespace JabbR
         {
             bool isTopicCleared = String.IsNullOrWhiteSpace(room.Topic);
             var parsedTopic = ConvertUrlsAndRoomLinks(room.Topic ?? "");
-            Clients[room.Name].topicChanged(isTopicCleared, parsedTopic, user.Name);
+            Clients[room.Name].topicChanged(room.Name, isTopicCleared, parsedTopic, user.Name);
             // Create the view model
             var roomViewModel = new RoomViewModel
             {


### PR DESCRIPTION
The event was originally tied to this.activeRoom since it was only sent to the
initiator who obviously had it focused. After the announcement change, if you
had set the room topic in client A, and client B was in that room but had a
different room active, he would have seen a message that the topic was changed,
but in his current room. Now we simply send down the room name so that we can
add the message to that channel.
