### PR TITLE
Display the user's id when the /who command is invoked on own user

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -468,9 +468,11 @@
             ui.addMessage('Note: ' + userInfo.Note, 'list-item');
         }
 
-        $.getJSON('https://secure.gravatar.com/' + userInfo.Hash + '.json?callback=?', function (profile) {
-            ui.showGravatarProfile(profile.entry[0]);
-        });
+        if (userInfo.Hash) {
+            $.getJSON('https://secure.gravatar.com/' + userInfo.Hash + '.json?callback=?', function(profile) {
+                ui.showGravatarProfile(profile.entry[0]);
+            });
+        }
 
         chat.showUsersOwnedRoomList(userInfo.Name, userInfo.OwnedRooms);
     };

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -467,7 +467,11 @@
         else if (userInfo.Note) {
             ui.addMessage('Note: ' + userInfo.Note, 'list-item');
         }
-
+        
+        if (userInfo.Id) {
+            ui.addMessage('Id: ' + userInfo.Id + " (don't share this!)", 'list-item');
+        }
+        
         if (userInfo.Hash) {
             $.getJSON('https://secure.gravatar.com/' + userInfo.Hash + '.json?callback=?', function(profile) {
                 ui.showGravatarProfile(profile.entry[0]);

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -775,8 +775,11 @@ namespace JabbR
         {
             string userId = GetUserId();
 
+            bool displayUserId = userId == user.Id;
+
             Caller.showUserInfo(new
             {
+                Id = displayUserId ? user.Id : string.Empty,
                 Name = user.Name,
                 OwnedRooms = user.OwnedRooms
                     .Allowed(userId)


### PR DESCRIPTION
I'm in the process of writing an app that can take the payload provided by GitHub's [post-receive hooks](https://help.github.com/articles/post-receive-hooks) and send the information into a Jabbr room.

To do so, I'm using the Jabbr.Client library which can authenticate using user/password combo, or using an id. Therefore it needs to be possible to expose your own userid.

Also doesn't render the gravatar info when the user's hash isn't set
