### PR TITLE
Use sparse ViewModel for lobby JSON

### DIFF
--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -265,12 +265,12 @@ namespace JabbR
             };
         }
 
-        public IEnumerable<RoomViewModel> GetRooms()
+        public IEnumerable<LobbyRoomViewModel> GetRooms()
         {
             string id = GetUserId();
             ChatUser user = _repository.VerifyUserId(id);
 
-            var rooms = _repository.GetAllowedRooms(user).Select(r => new RoomViewModel
+            var rooms = _repository.GetAllowedRooms(user).Select(r => new LobbyRoomViewModel
             {
                 Name = r.Name,
                 Count = r.Users.Count(u => u.Status != (int)UserStatus.Offline),

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -856,6 +856,7 @@
     <Compile Include="Migrations\201208211555032_BanUser.Designer.cs">
       <DependentUpon>201208211555032_BanUser.cs</DependentUpon>
     </Compile>
+    <Compile Include="ViewModels\LobbyRoomViewModel.cs" />
     <Compile Include="WebApi\Model\ErrorModel.cs" />
     <Compile Include="Infrastructure\HttpRequestExtensions.cs" />
     <Compile Include="WebApi\MessagesController.cs" />

--- a/JabbR/ViewModels/LobbyRoomViewModel.cs
+++ b/JabbR/ViewModels/LobbyRoomViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace JabbR.ViewModels
+{
+    public class LobbyRoomViewModel
+    {
+        public string Name { get; set; }
+        public int Count { get; set; }
+        public bool Private { get; set; }
+        public bool Closed { get; set; }
+    }
+}


### PR DESCRIPTION
Currently tabbing into the lobby causes a >100KB JSON payload.
This can be reduced by removing properties not used by the Lobby:
- Topic
- Users
- Welcome
- Owners
- Recent Messages
