### PR TITLE
Allow multiple whitespaces between command arguments

### DIFF
--- a/JabbR.Tests/CommandManagerFacts.cs
+++ b/JabbR.Tests/CommandManagerFacts.cs
@@ -12,6 +12,76 @@ namespace JabbR.Test
 {
     public class CommandManagerFacts
     {
+        public class ParseCommand
+        {
+            [Fact]
+            public void ReturnsTheCommandName()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var service = new ChatService(cache, repository, new Mock<ICryptoService>().Object);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("id", "id", "name", service, repository, cache, notificationService.Object);
+
+                const string commandName = "thecommand";
+                string[] args;
+                var parsedName = commandManager.ParseCommand(String.Format("/{0}", commandName), out args);
+
+                Assert.Equal(commandName, parsedName);
+            }
+
+            [Fact]
+            public void ParsesTheArguments()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var service = new ChatService(cache, repository, new Mock<ICryptoService>().Object);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("id", "id", "name", service, repository, cache, notificationService.Object);
+            
+                var parts = new[] {"/cmd", "arg0", "arg1", "arg2"};
+                var command = String.Join(" ", parts);
+                
+                string[] parsedArgs;
+                commandManager.ParseCommand(command, out parsedArgs);
+
+                Assert.Equal(parts.Skip(1), parsedArgs);
+            }
+
+            [Fact]
+            public void IgnoresMultipleWhitespaceBetweenArguments()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var service = new ChatService(cache, repository, new Mock<ICryptoService>().Object);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("id", "id", "name", service, repository, cache, notificationService.Object);
+                
+                var parts = new[] { "/cmd", "arg0", "arg1", "arg2" };
+                var command = String.Join("    ", parts);
+
+                string[] parsedArgs;
+                commandManager.ParseCommand(command, out parsedArgs);
+
+                Assert.Equal(parts.Skip(1), parsedArgs);
+            }
+
+            [Fact]
+            public void ProducesEmptyArrayIfNoArguments()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var service = new ChatService(cache, repository, new Mock<ICryptoService>().Object);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("id", "id", "name", service, repository, cache, notificationService.Object);
+
+                string[] parsedArgs;
+                commandManager.ParseCommand("/cmd", out parsedArgs);
+
+                Assert.Equal(0, parsedArgs.Length);
+            }
+        }
+
         public class TryHandleCommand
         {
             [Fact]

--- a/JabbR/Commands/CommandManager.cs
+++ b/JabbR/Commands/CommandManager.cs
@@ -51,6 +51,12 @@ namespace JabbR.Commands
             _notificationService = notificationService;
         }
 
+        public string ParseCommand(string commandString, out string[] args)
+        {
+            var parts = commandString.Substring(1).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            args = parts.Skip(1).ToArray();
+            return parts[0];
+        }
         public bool TryHandleCommand(string command)
         {
             command = command.Trim();
@@ -59,10 +65,9 @@ namespace JabbR.Commands
                 return false;
             }
 
-            string[] args = command.Substring(1).Split(' ');
-            string commandName = args[0];
-
-            return TryHandleCommand(commandName, args.Skip(1).ToArray());
+            string[] args;
+            var commandName = ParseCommand(command, out args);
+            return TryHandleCommand(commandName, args);
         }
 
         public bool TryHandleCommand(string commandName, string[] args)


### PR DESCRIPTION
Earlier today I noticed that if you use two spaces in a command like "/join  foo", you get "Room name cannot be blank!". I made a quick fix for it and added some basic tests for the new code.
