### PR TITLE
Set Null initializer for EF and use LocalDb

### DIFF
--- a/JabbR/Models/JabbrContext.cs
+++ b/JabbR/Models/JabbrContext.cs
@@ -10,6 +10,11 @@ namespace JabbR.Models
         {
         }
 
+        static JabbrContext()
+        {
+            Database.SetInitializer<JabbrContext>(null);
+        }
+
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
             modelBuilder.Configurations.Add(new ChatClientMap());

--- a/JabbR/Web.config
+++ b/JabbR/Web.config
@@ -13,7 +13,7 @@
     <iriParsing enabled="true" />
   </uri>
   <connectionStrings>
-    <add name="Jabbr" connectionString="Data Source=.\SQLEXPRESS;Initial Catalog=JabbR;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="Jabbr" connectionString="Data Source=(localdb)\v11.0;Initial Catalog=JabbR;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Enabled" value="false" />

--- a/JabbR/Web.config
+++ b/JabbR/Web.config
@@ -13,7 +13,7 @@
     <iriParsing enabled="true" />
   </uri>
   <connectionStrings>
-    <add name="Jabbr" connectionString="Data Source=(localdb)\v11.0;Initial Catalog=JabbR;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="Jabbr" connectionString="Data Source=.\SQLEXPRESS;Initial Catalog=JabbR;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Enabled" value="false" />


### PR DESCRIPTION
set null initializer for entity framework to prevent weird startup issues when db doesn't exist and use local db instead of sql express

@davidfowl any objections?

I noticed that without the null initializer, EF was creating the db for me then failing to run the migrations because the schema was created based on the newer model (very odd).

and I think we should just use localdb :smile: 
