### PR TITLE
Add support to enable the flags of British home nations

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -1187,7 +1187,7 @@ li.clearfix
     background-position: -208px -33px;
   }
 
-  .flag.flag-england
+  .flag.flag-g1
   {
     background-position: -224px -33px;
   }
@@ -1837,7 +1837,7 @@ li.clearfix
     background-position: -240px -121px;
   }
 
-  .flag.flag-zz
+  .flag.flag-g3
   {
     background-position: 0 -132px;
   }
@@ -2067,7 +2067,7 @@ li.clearfix
     background-position: -208px -154px;
   }
 
-  .flag.flag-wales
+  .flag.flag-g2
   {
     background-position: -224px -154px;
   }

--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -1837,7 +1837,7 @@ li.clearfix
     background-position: -240px -121px;
   }
 
-  .flag.flag-scotland
+  .flag.flag-zz
   {
     background-position: 0 -132px;
   }

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -268,7 +268,9 @@ namespace JabbR.Services
                                                                                 {"za", "South Africa"},
                                                                                 {"zm", "Zambia"},
                                                                                 {"zw", "Zimbabwe"},
-                                                                                {"zz", "Scotland"}
+                                                                                {"g1", "England"},
+                                                                                {"g2", "Wales"},
+                                                                                {"g3", "Scotland"}
                                                   };
 
         public ChatService(ICache cache, IJabbrRepository repository)

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -267,7 +267,8 @@ namespace JabbR.Services
                                                                                 {"yt", "Mayotte"},
                                                                                 {"za", "South Africa"},
                                                                                 {"zm", "Zambia"},
-                                                                                {"zw", "Zimbabwe"}
+                                                                                {"zw", "Zimbabwe"},
+                                                                                {"zz", "Scotland"}
                                                   };
 
         public ChatService(ICache cache, IJabbrRepository repository)


### PR DESCRIPTION
Utilised non ISO standard codes to enable the flags for British home nations

G1 - England,
G2 - Wales,
G3 - Scotland
