### PR TITLE
Fixing userlist-header

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -2660,6 +2660,7 @@ pre
 h3.userlist-header
 {
     padding: 3px 0;
+    margin: 16px 0 0 0;
 }
 
 .modal, .modal-header


### PR DESCRIPTION
This is to remove the extraneous space after the userlist header so that
the lists aren't so separated from their headers.
