### PR TITLE
Update Twitter provider text to ensure that header tags are not huge, fixes #685

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -2725,7 +2725,8 @@ h3.userlist-header
     padding-bottom: 0;
 }
 
-.git-hub-issue .starting-comment h2 {
+.git-hub-issue .starting-comment h2,
+.tweet h1 {
     font-size: 13px;
     margin: 0;
     line-height: 13px;

--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -2726,7 +2726,7 @@ h3.userlist-header
 }
 
 .git-hub-issue .starting-comment h2,
-.tweet h1 {
+.tweet h1, .tweet h2, .tweet h3, .tweet h4 {
     font-size: 13px;
     margin: 0;
     line-height: 13px;


### PR DESCRIPTION
![UpdatedTwitterProvider](https://f.cloud.github.com/assets/1035315/126711/5342dd70-6f6e-11e2-90cb-72432d8a76d3.png)
