### PR TITLE
Disable file upload on lobby and in closed rooms

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -2066,11 +2066,13 @@
                 $hiddenFile.attr('disabled', 'disabled');
                 $submitButton.attr('disabled', 'disabled');
                 $newMessage.attr('disabled', 'disabled');
+                $fileUploadButton.attr('disabled', 'disabled');
             }
             else {
                 $hiddenFile.removeAttr('disabled');
                 $submitButton.removeAttr('disabled');
                 $newMessage.removeAttr('disabled');
+                $fileUploadButton.removeAttr('disabled');
             }
         },
         initializeConnectionStatus: function (transport) {
@@ -2133,10 +2135,11 @@
         collapseRichContent: collapseRichContent,
         toggleMessageSection: function (disabledIt) {
             if (disabledIt) {
-                // disable button and textarea
+                // disable send button, textarea and file upload
                 $newMessage.attr('disabled', 'disabled');
                 $submitButton.attr('disabled', 'disabled');
-
+                $fileUploadButton.attr('disabled', 'disabled');
+                $hiddenFile.attr('disabled', 'disabled');
             } else if (!readOnly) {
                 // re-enable textarea button
                 $newMessage.attr('disabled', '');
@@ -2145,6 +2148,12 @@
                 // re-enable submit button
                 $submitButton.attr('disabled', '');
                 $submitButton.removeAttr('disabled');
+                
+                // re-enable file upload button
+                $fileUploadButton.attr('disabled', '');
+                $fileUploadButton.removeAttr('disabled');
+                $hiddenFile.attr('disabled', '');
+                $hiddenFile.removeAttr('disabled');
             }
         },
         closeRoom: function (roomName) {

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -388,8 +388,15 @@ namespace JabbR.Services
 
         public ChatMessage AddMessage(string userId, string roomName, string content)
         {
-            var user = _repository.GetUserById(userId);
-            var room = _repository.GetRoomByName(roomName);
+            ChatUser user = _repository.VerifyUserId(userId);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName);
+
+            // REVIEW: Is it better to use _repository.VerifyRoom(message.Room, mustBeOpen: false)
+            // here?
+            if (room.Closed)
+            {
+                throw new InvalidOperationException(String.Format("You cannot post messages to '{0}'. The room is closed.", roomName));
+            }
 
             var message = AddMessage(user, room, Guid.NewGuid().ToString("d"), content);
 

--- a/JabbR/Services/UploadCallbackHandler.cs
+++ b/JabbR/Services/UploadCallbackHandler.cs
@@ -45,7 +45,8 @@ namespace JabbR.Services
                 return;
             }
 
-            string contentUrl = null;
+            string contentUrl;
+            ChatMessage message;
 
             try
             {
@@ -56,15 +57,15 @@ namespace JabbR.Services
                     _hubContext.Clients.Client(connectionId).postMessage("Failed to upload " + Path.GetFileName(file) + ".", "error", roomName);
                     return;
                 }
+
+                // Add the message to the persistent chat
+                message = _service.AddMessage(userId, roomName, contentUrl);
             }
             catch (Exception ex)
             {
                 _hubContext.Clients.Client(connectionId).postMessage("Failed to upload " + Path.GetFileName(file) + ". " + ex.Message, "error", roomName);
                 return;
             }
-
-            // Add the message to the persistent chat
-            ChatMessage message = _service.AddMessage(userId, roomName, contentUrl);
 
             var messageViewModel = new MessageViewModel(message);
 


### PR DESCRIPTION
The file upload button (and backing file upload control) is not disabled in the lobby and closed rooms.

File uploads succeed in closed rooms (though changes are not displayed) and the upload seems to be added to the room history.

Should fix issue #745
