### PR TITLE
When the last user exits a room, show 'no users' to remaining room owners

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1631,6 +1631,8 @@
 
                     if (owner === true) {
                         room.setListState(room.owners);
+                    } else {
+                        room.setListState(room.activeUsers);
                     }
                 });
         },


### PR DESCRIPTION
When the last non-room-owner user exits a room, the users menu does not currently update to show "No users".

![jabbr-room-last-user-leaves](https://f.cloud.github.com/assets/1271535/306967/93ecad32-96a7-11e2-8e5f-0e3cd7785dc3.png)

This functionality does work when the last owner leaves.
