### PR TITLE
CommandManager now throws on unmatched command

### DIFF
--- a/JabbR.Tests/CommandManagerFacts.cs
+++ b/JabbR.Tests/CommandManagerFacts.cs
@@ -128,7 +128,7 @@ namespace JabbR.Test
             }
 
             [Fact]
-            public void ReturnsFalseIfCommandDoesntExists()
+            public void ThrowsIfCommandDoesntExist ()
             {
                 var repository = new InMemoryRepository();
                 var cache = new Mock<ICache>().Object;
@@ -151,9 +151,7 @@ namespace JabbR.Test
                 repository.Add(room);
                 var commandManager = new CommandManager("1", "1", "room", service, repository, cache, notificationService.Object);
 
-                bool result = commandManager.TryHandleCommand("/foo");
-
-                Assert.False(result);
+                Assert.Throws<InvalidOperationException> (() => commandManager.TryHandleCommand ("/message"));
             }
 
             [Fact]

--- a/JabbR/Commands/CommandManager.cs
+++ b/JabbR/Commands/CommandManager.cs
@@ -113,7 +113,7 @@ namespace JabbR.Commands
             }
             catch (CommandNotFoundException)
             {
-                return false;
+                throw new InvalidOperationException(String.Format("'{0}' is not a valid command.", commandName));
             }
             catch (CommandAmbiguityException e)
             {


### PR DESCRIPTION
b/c why should the chat room see invalid or mistyped commands?
