### PR TITLE
Constrain username textbox maxlength

### DIFF
--- a/JabbR/Nancy/InputExtensions.cs
+++ b/JabbR/Nancy/InputExtensions.cs
@@ -18,7 +18,12 @@ namespace JabbR
 
         public static IHtmlString TextBox<TModel>(this HtmlHelpers<TModel> htmlHelper, string propertyName, string className, string placeholder)
         {
-            return InputHelper(htmlHelper, "text", propertyName, htmlHelper.GetValueForProperty(propertyName), className, placeholder);
+            return TextBox(htmlHelper, propertyName, className, placeholder, null);
+        }
+
+        public static IHtmlString TextBox<TModel>(this HtmlHelpers<TModel> htmlHelper, string propertyName, string className, string placeholder, int? maxLength)
+        {
+            return InputHelper(htmlHelper, "text", propertyName, htmlHelper.GetValueForProperty(propertyName), className, placeholder, maxLength);
         }
 
         public static IHtmlString Password<TModel>(this HtmlHelpers<TModel> htmlHelper, string propertyName)
@@ -33,15 +38,32 @@ namespace JabbR
 
         public static IHtmlString Password<TModel>(this HtmlHelpers<TModel> htmlHelper, string propertyName, string className, string placeholder)
         {
-            return InputHelper(htmlHelper, "password", propertyName, null, className, placeholder);
+            return Password(htmlHelper, propertyName, className, placeholder, null);
         }
 
-        private const string InputTemplate = @"<input type=""{0}"" id=""{1}"" name=""{2}"" value=""{3}"" class=""{4}"" placeholder=""{5}"" />";
-        private static IHtmlString InputHelper<TModel>(HtmlHelpers<TModel> htmlHelper, string inputType, string propertyName, string value, string className, string placeholder)
+        public static IHtmlString Password<TModel>(this HtmlHelpers<TModel> htmlHelper, string propertyName, string className, string placeholder, int? maxLength)
+        {
+            return InputHelper(htmlHelper, "password", propertyName, null, className, placeholder, maxLength);
+        }
+
+        private const string InputTemplate = @"<input type=""{0}"" id=""{1}"" name=""{2}"" value=""{3}"" class=""{4}"" {5} />";
+        private static IHtmlString InputHelper<TModel>(HtmlHelpers<TModel> htmlHelper, string inputType, string propertyName, string value, string className, string placeholder, int? maxLength)
         {
             bool hasError = htmlHelper.GetErrorsForProperty(propertyName).Any();
 
-            return new NonEncodedHtmlString(String.Format(InputTemplate, inputType, propertyName, propertyName, value, hasError ? String.Format("{0} {1}", className, "error").Trim() : className, placeholder));
+            string additionalProperties = string.Empty;
+
+            if (!string.IsNullOrEmpty(placeholder))
+            {
+                additionalProperties += string.Format(@"placeholder=""{0}"" ", placeholder);
+            }
+            
+            if (maxLength != null)
+            {
+                additionalProperties += string.Format(@"maxlength=""{0}"" ", maxLength);
+            }
+
+            return new NonEncodedHtmlString(String.Format(InputTemplate, inputType, propertyName, propertyName, value, hasError ? String.Format("{0} {1}", className, "error").Trim() : className, additionalProperties));
         }
 
         internal static string GetValueForProperty<TModel>(this HtmlHelpers<TModel> htmlHelper, string propertyName)

--- a/JabbR/Views/Account/_username.cshtml
+++ b/JabbR/Views/Account/_username.cshtml
@@ -5,7 +5,7 @@
             <div class="controls">
                 <div class="input-prepend">
                     <span class="add-on"><i class="icon-user"></i></span>
-                    @Html.TextBox("username", "input-block-level", "Username")
+                    @Html.TextBox("username", "input-block-level", "Username", 30)
                 </div>
             </div>
         </div>

--- a/JabbR/Views/Account/index.cshtml
+++ b/JabbR/Views/Account/index.cshtml
@@ -76,13 +76,13 @@
                                 <div class="control-group">
                                     <label class="control-label" for="username">Username</label>
                                     <div class="controls">
-                                        @Html.TextBox("username", "input-xlarge", "Username")
+                                        @Html.TextBox("username", "input-xlarge", "Username", 30)
                                     </div>
                                 </div>
                                 <div class="control-group">
                                     <label class="control-label" for="confirmUsername">Confirm Username</label>
                                     <div class="controls">
-                                        @Html.TextBox("confirmUsername", "input-xlarge", "Confirm Username")
+                                        @Html.TextBox("confirmUsername", "input-xlarge", "Confirm Username", 30)
                                     </div>
                                 </div>
                                 <div class="control-group">


### PR DESCRIPTION
Make it so that username fields have maxlength of 30 (hardcoded) so that you can't provide a username longer than the system will accept on the login / profile pages.  Update generation to include the placeholder and maxlength only when they're necessary.

I'm not sure whether I think it's a worthwhile change but figured I'd PR it anyway, so feel free to just close if it's not DRY enough etc.
