### PR TITLE
Userlist top is 1px off

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -172,14 +172,12 @@ form#send-message {
 {
   border: 1px solid #ccc;
   overflow: auto;
-  margin-left: 0px;
-  margin-top: 0px;
-  padding-left: 0px;
+  margin: 0;
   left: 0;
   right: 236px;
   position: absolute;
   top: 55px;
-  bottom: 40px;
+  bottom: 50px;
   background-color: #fff;
 }
 
@@ -223,7 +221,7 @@ form#send-message {
 {
   font-size: small;
   position: absolute;
-  top: 56px;
+  top: 55px;
   right: 0;
   width: 235px;
   bottom: 50px;


### PR DESCRIPTION
Top shows existing behaviour, bottom shows new.  Ridiculously minor OCD-level change.

![jabbr-users-top](https://f.cloud.github.com/assets/1271535/319118/193efcfe-98b2-11e2-9244-2de4e88b517b.png)

This also clarifies the messages UL's margins (overriding [somewhat arbitrary padding] inherited from bootstrap's ul class)
