### PR TITLE
Make file upload button show pointer.

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -127,6 +127,7 @@ form#send-message {
 }
 
 .upload-button input {
+    cursor: pointer;
     position: absolute;
     top: 0;
     left: 0;
@@ -134,6 +135,10 @@ form#send-message {
     font-size: 70px;
     opacity: 0;
     filter: alpha(opacity=0);
+}
+
+.upload-button input[disabled] {
+    cursor: inherit;
 }
 
 #heading


### PR DESCRIPTION
At the moment, the file upload button shows the default cursor rather than a pointer.  This change turns it into a pointer unless it's disabled.
