### PR TITLE
Fix up github issue provider style to correct bubble arrow 404 and add avatar rounding

### DIFF
--- a/JabbR/Chat.githubissues.css
+++ b/JabbR/Chat.githubissues.css
@@ -207,14 +207,29 @@
 }
 
 .avatar-bubble {
-    background: url("https://github.com/images/modules/comments/bubble-arrow.png") no-repeat scroll 51px 20px transparent;
     margin: 20px 0;
     padding-left: 60px;
+    position: relative;
 }
 .avatar-bubble .avatar {
     float: left;
     margin-left: -60px;
     position: relative;
+}
+.avatar-bubble .avatar img {
+    border-radius: 3px;
+}
+.avatar-bubble .bubble:before {
+    content: '';
+    display: block;
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 10px 10px 10px 0;
+    border-color: transparent #EEEEEE transparent transparent;
+    left: 50px;
+    top: 15px;
 }
 .avatar-bubble .bubble {
     background: none repeat scroll 0 0 #EEEEEE;


### PR DESCRIPTION
At current, the github issues provider emits dom elements that cause a 404 in styling.  https://github.com/images/modules/comments/bubble-arrow.png is referenced in the css (and used) but does not exist.  It seems that it used to be for a little arrow that connects the user's avatar to their speech bubble.  We can make this arrow in css (this is what github does now).

Avatars are also now slightly rounded with css (github now does this as well).
![jabbr-github-404-arrow-rounding](https://f.cloud.github.com/assets/1271535/326227/50f145cc-9b27-11e2-8aaa-669f022443e9.png)
