### PR TITLE
message history trimming on timer

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -767,6 +767,7 @@
             typing = true;
 
             try {
+                ui.setRoomTrimmable(chat.state.activeRoom, typing);
                 chat.server.typing(chat.state.activeRoom);
             }
             catch (e) {
@@ -941,6 +942,7 @@
         try {
             // Show a little animation so the user experience looks fancy
             ui.setLoadingHistory(loadingHistory);
+            ui.setRoomTrimmable(roomInfo.name, false);
             connection.hub.log('getPreviousMessages(' + roomInfo.name + ')');
             chat.server.getPreviousMessages(roomInfo.messageId)
                 .done(function (messages) {

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -975,10 +975,6 @@
         logout();
     });
 
-    $(ui).bind(ui.events.trimMessageHistory, function(ev, roomName) {
-        ui.trimRoomMessageHistory(roomName);
-    });
-
     $(function () {
         var stateCookie = $.cookie('jabbr.state'),
             state = stateCookie ? JSON.parse(stateCookie) : {},

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -973,6 +973,10 @@
         logout();
     });
 
+    $(ui).bind(ui.events.trimMessageHistory, function(ev, roomName) {
+        ui.trimRoomMessageHistory(roomName);
+    });
+
     $(function () {
         var stateCookie = $.cookie('jabbr.state'),
             state = stateCookie ? JSON.parse(stateCookie) : {},

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -432,6 +432,28 @@
                 listToSort.append(item);
             });
         };
+
+        this.trimHistory = function (numberOfMessagesToKeep) {
+            var lastIndex = null,
+                $messagesToRemove = null,
+                $roomMessages = this.messages.find('li'),
+                messageCount = $roomMessages.length;
+            
+            numberOfMessagesToKeep = numberOfMessagesToKeep || 500;
+
+            if (numberOfMessagesToKeep < 500) {
+                numberOfMessagesToKeep = 500;
+            }
+            
+            if (messageCount < numberOfMessagesToKeep) {
+                return;
+            }
+
+            lastIndex = messageCount - numberOfMessagesToKeep;
+            $messagesToRemove = $roomMessages.filter('li:lt(' + lastIndex + ')');
+
+            $messagesToRemove.remove();
+        };
     }
 
     function getRoomElements(roomName) {
@@ -876,6 +898,7 @@
             loggedOut: 'jabbr.ui.loggedOut',
             reloadMessages: 'jabbr.ui.reloadMessages',
             fileUploaded: 'jabbr.ui.fileUploaded',
+            trimMessageHistory: 'jabbr.ui.trimMessageHistory',
         },
 
         help: {
@@ -2256,6 +2279,14 @@
 
                 return content;
             }
+        },
+        trimRoomMessageHistory: function(roomName) {
+            var room = getRoomElements(roomName);
+
+            // ensure room history should actually be trimmed...
+            // user is idle?
+
+            room.trimHistory();
         }
     };
 

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -69,7 +69,7 @@
         connectionInfoTransport = null,
         $topicBar = null,
         $loadingHistoryIndicator = null,
-        trimRoomHistoryMaxMessages = 500,
+        trimRoomHistoryMaxMessages = 100,
         trimRoomHistoryFrequency = 1000 * 60 * 2; // 2 minutes in ms
 
     function getRoomNameFromHash(hash) {

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -912,7 +912,6 @@
             loggedOut: 'jabbr.ui.loggedOut',
             reloadMessages: 'jabbr.ui.reloadMessages',
             fileUploaded: 'jabbr.ui.fileUploaded',
-            trimMessageHistory: 'jabbr.ui.trimMessageHistory',
         },
 
         help: {
@@ -1410,7 +1409,7 @@
             });
 
             setInterval(function() {
-                $ui.trigger(ui.events.trimMessageHistory);
+	            ui.trimRoomMessageHistory();
             }, trimRoomHistoryFrequency);
         },
         run: function () {

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -69,7 +69,7 @@
         connectionInfoTransport = null,
         $topicBar = null,
         $loadingHistoryIndicator = null,
-        trimRoomHistoryMaxMessages = 100,
+        trimRoomHistoryMaxMessages = 150,
         trimRoomHistoryFrequency = 1000 * 60 * 2; // 2 minutes in ms
 
     function getRoomNameFromHash(hash) {

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -101,7 +101,7 @@
         </div>
     </script>
     <script id="new-tab-template" type="text/x-jquery-tmpl">
-        <li id="tabs-${id}" class="room" data-name="${name}" data-closed="${closed}" role="tab">
+        <li id="tabs-${id}" class="room" data-name="${name}" data-closed="${closed}" data-trimmable="true" role="tab">
             <span class="lock"></span>
             <span class="readonly"></span>
             <button> 
@@ -202,7 +202,7 @@
         </div>
     <nav>
       <ul id="tabs" role="tablist">
-        <li id="tabs-lobby" class="current lobby" data-name="Lobby" role="tab">
+        <li id="tabs-lobby" class="current lobby" data-name="Lobby" data-trimmable="false" role="tab">
           <button accesskey="l">
             <span class="content">Lobby</span>
           </button>


### PR DESCRIPTION
uses a timer to trim the message history for the currently open rooms.
- skips lobby
- only trims rooms that have been typed in since last history fetch
- trims messages exceeding 500

@davidfowl @alfhenrik 
