### PR TITLE
Added Ms Office docs content provider support

### DIFF
--- a/JabbR/ContentProviders/Core/EmbedContentProvider.cs
+++ b/JabbR/ContentProviders/Core/EmbedContentProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace JabbR.ContentProviders.Core
@@ -20,10 +19,10 @@ namespace JabbR.ContentProviders.Core
                 return TaskAsyncHelper.FromResult<ContentProviderResult>(null);
             }
 
-            return TaskAsyncHelper.FromResult(new ContentProviderResult()
+            return TaskAsyncHelper.FromResult(new ContentProviderResult
              {
                  Content = String.Format(MediaFormatString, args.ToArray()),
-                 Title = request.RequestUri.AbsoluteUri.ToString()
+                 Title = request.RequestUri.AbsoluteUri
              });
         }
 

--- a/JabbR/ContentProviders/MicrosoftOfficeDocsContentProvider.cs
+++ b/JabbR/ContentProviders/MicrosoftOfficeDocsContentProvider.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using JabbR.ContentProviders.Core;
+
+namespace JabbR.ContentProviders
+{
+    public class MicrosoftOfficeDocsContentProvider : EmbedContentProvider
+    {
+        private const string EmbedCode =
+            @"<iframe src=""https://view.officeapps.live.com/op/embed.aspx?src={0}"" width=""100%;"" height=""400px"" frameborder=""0"">";
+
+        private readonly List<string> _supportedExtensions = new List<string>
+            {
+                "xlsx",
+                "xls",
+                "docx",
+                "doc",
+                "pptx",
+                "ppt",
+            };
+
+        public override IEnumerable<string> Domains
+        {
+            get
+            {
+                yield return Uri.UriSchemeHttp;
+                yield return Uri.UriSchemeHttps;
+            }
+        }
+
+        public override string MediaFormatString
+        {
+            get { return EmbedCode; }
+        }
+
+        public override bool IsValidContent(Uri uri)
+        {
+            return base.IsValidContent(uri) && _supportedExtensions.Any(str => uri.AbsolutePath.EndsWith(str));
+        }
+
+        protected override IList<string> ExtractParameters(Uri responseUri)
+        {
+            return new List<string>
+                {
+                    responseUri.AbsoluteUri
+                };
+        }
+    }
+}

--- a/JabbR/ContentProviders/MicrosoftOfficeDocsContentProvider.cs
+++ b/JabbR/ContentProviders/MicrosoftOfficeDocsContentProvider.cs
@@ -11,7 +11,7 @@ namespace JabbR.ContentProviders
         private const string EmbedCode =
             @"<iframe src=""https://view.officeapps.live.com/op/embed.aspx?src={0}"" width=""100%;"" height=""400px"" frameborder=""0"">";
 
-        private readonly List<string> _supportedExtensions = new List<string>
+        private static readonly List<string> SupportedExtensions = new List<string>
             {
                 "xlsx",
                 "xls",
@@ -37,7 +37,7 @@ namespace JabbR.ContentProviders
 
         public override bool IsValidContent(Uri uri)
         {
-            return base.IsValidContent(uri) && _supportedExtensions.Any(str => uri.AbsolutePath.EndsWith(str));
+            return base.IsValidContent(uri) && SupportedExtensions.Any(str => uri.AbsolutePath.EndsWith(str));
         }
 
         protected override IList<string> ExtractParameters(Uri responseUri)

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -882,7 +882,7 @@
       <DependentUpon>201303220549121_ContentProviderContent.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Migrations\201303302002539_Attachments.resx">
-        <DependentUpon>201303302002539_Attachments.cs</DependentUpon>
+      <DependentUpon>201303302002539_Attachments.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Migrations\201303302058326_AttachmentMetadata.resx">
       <DependentUpon>201303302058326_AttachmentMetadata.cs</DependentUpon>
@@ -954,6 +954,7 @@
   <ItemGroup>
     <Compile Include="App_Start\Startup.DependencyInjection.cs" />
     <Compile Include="ContentProviders\Core\ContentProviderProcessor.cs" />
+    <Compile Include="ContentProviders\MicrosoftOfficeDocsContentProvider.cs" />
     <Compile Include="ContentProviders\GitHubIssueCommentsContentProvider.cs" />
     <Compile Include="Infrastructure\AuthenticationServiceExtensions.cs" />
     <Compile Include="Infrastructure\CryptoHelper.cs" />
@@ -966,7 +967,7 @@
     </Compile>
     <Compile Include="Migrations\201303302002539_Attachments.cs" />
     <Compile Include="Migrations\201303302002539_Attachments.Designer.cs">
-        <DependentUpon>201303302002539_Attachments.cs</DependentUpon>
+      <DependentUpon>201303302002539_Attachments.cs</DependentUpon>
     </Compile>
     <Compile Include="Migrations\201303302058326_AttachmentMetadata.cs" />
     <Compile Include="Migrations\201303302058326_AttachmentMetadata.Designer.cs">


### PR DESCRIPTION
The idea is to use the office web apps every time someone pastes a URL that points to an office document. This is the basic implementation of that functionality.

This is how it looks like:

![excel](https://f.cloud.github.com/assets/351117/360685/6b3382ec-a1a3-11e2-9d96-ed42d436a8c4.PNG)

![pp](https://f.cloud.github.com/assets/351117/360686/72277e5a-a1a3-11e2-98d0-98d855a52bc0.PNG)
