### PR TITLE
old-ie gradients mess up rounding on connection status and user status

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -485,7 +485,6 @@ form#send-message {
     box-shadow: inset 0px 1px 0px 0px #caefab;
     background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #77d42a), color-stop(1, #5cb811) );
     background: -moz-linear-gradient( center top, #77d42a 5%, #5cb811 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#77d42a', endColorstr='#5cb811');
     background-color: #77d42a;
     -webkit-border-radius: 8px;
     -moz-border-radius: 8px;
@@ -513,7 +512,6 @@ li.user.typing .user-status {
     box-shadow: inset 0px 1px 0px 0px #fff6af;
     background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #ffec64), color-stop(1, #ffab23) );
     background: -moz-linear-gradient( center top, #ffec64 5%, #ffab23 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffec64', endColorstr='#ffab23');
     background-color: #ffec64;
     border: 1px solid #ffaa22;
 }
@@ -2724,7 +2722,6 @@ h3.userlist-header {
     box-shadow: inset 0px 1px 0px 0px #caefab;
     background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #77d42a), color-stop(1, #5cb811) );
     background: -moz-linear-gradient( center top, #77d42a 5%, #5cb811 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#77d42a', endColorstr='#5cb811');
     background-color: #77d42a;
     -webkit-border-radius: 8px;
     -moz-border-radius: 8px;
@@ -2741,7 +2738,6 @@ h3.userlist-header {
     box-shadow: inset 0px 1px 0px 0px #fff6af;
     background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #ffec64), color-stop(1, #ffab23) );
     background: -moz-linear-gradient( center top, #ffec64 5%, #ffab23 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffec64', endColorstr='#ffab23');
     background-color: #ffec64;
     border: 1px solid #ffaa22;
 }
@@ -2752,7 +2748,6 @@ h3.userlist-header {
     box-shadow: inset 0px 1px 0px 0px #f29c93;
     background: -webkit-gradient( linear, left top, left bottom, color-stop(0.05, #fe1a00), color-stop(1, #ce0100) );
     background: -moz-linear-gradient( center top, #fe1a00 5%, #ce0100 100% );
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fe1a00', endColorstr='#ce0100');
     background-color: #fe1a00;
     border: 1px solid #d83526;
 }


### PR DESCRIPTION
Unfortunately we lose some 3d-edness on these elements in IE9 and earlier.

The problem is described at http://stackoverflow.com/questions/6130235/ie9-rounded-corners-css-background-gradients-living-together and http://stackoverflow.com/questions/4692686/ie9-border-radius-and-background-gradient-bleeding

It's possible to work around with box-shadow (in the second link above) but it's a bit of a hack, and the graidents were quite subtle to begin with.

![jabbr-ie9-status](https://f.cloud.github.com/assets/1271535/379226/9e6787f6-a58d-11e2-85cb-152f32d7be8a.png)
