### PR TITLE
Configure livestamp interval to decrease unecessary UI updates and reduce CPU cycles

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1284,6 +1284,9 @@
                 $ui.trigger(ui.events.fileUploaded, [uploader]);
             });
 
+            // Configure livestamp to only update every 30s since display granularity is by minute anyway (saves CPU cycles)
+            $.livestamp.interval(30 * 1000);
+
             setInterval(function () {
                 ui.trimRoomMessageHistory();
             }, trimRoomHistoryFrequency);


### PR DESCRIPTION
When sitting relatively idle (e.g. no real message traffic coming through) I noticed my JabbR tab instance was still using a constant 3-4% CPU. I profiled for a bit and ultimately this lead back to the fact that the livestamp plug-in had its default interval of one second and was therefore attempting to update all timestamps in the UI every second. Depending on how many rooms your in and how many people there are this can be a rather "costly" operation to be performing every second. At the time I was profiling it appeared to be updating ~400 elements every second and was taking _~255ms_ each time.

The UI where livestamp is used today is the user list, specifically to show how long a user has been inactive, only requires a granularity of minutes and obviously does not need to be precise so we can easily increase the livestamp interval to alleviate the amount of CPU cycles spent on this operation.

Bonus value: there will be much less contention in the UI thread per second now leaving plenty of room for other operations to perform their work.
