### PR TITLE
Hide user list container element before sorting

### DIFF
--- a/JabbR/Chat.ui.room.js
+++ b/JabbR/Chat.ui.room.js
@@ -315,26 +315,33 @@
     Room.prototype.sortList = function (listToSort) {
         var listItems = listToSort.children('li:not(.empty)').get();
 
-        var activeUsers = [],
-            idleUsers = [],
-            sortedUsers = [];
+        if (listItems.length > 0) {
+            var originalDisplayMode = listToSort.css("display"),
+                activeUsers = [],
+                idleUsers = [],
+                sortedUsers = [];
 
-        $.each(listItems, function (index, item) {
-            if ($(item).data('active')) {
-                activeUsers.push(item);
-            } else {
-                idleUsers.push(item);
-            }
-        });
+            listToSort.css("display", "none");
 
-        activeUsers = this.sortUsersByName(activeUsers);
-        idleUsers = this.sortUsersByName(idleUsers);
+            $.each(listItems, function (index, item) {
+                if ($(item).data('active')) {
+                    activeUsers.push(item);
+                } else {
+                    idleUsers.push(item);
+                }
+            });
 
-        sortedUsers = activeUsers.concat(idleUsers);
+            activeUsers = this.sortUsersByName(activeUsers);
+            idleUsers = this.sortUsersByName(idleUsers);
 
-        $.each(sortedUsers, function (index, item) {
-            listToSort.append(item);
-        });
+            sortedUsers = activeUsers.concat(idleUsers);
+
+            $.each(sortedUsers, function (index, item) {
+                listToSort.append(item);
+            });
+
+            listToSort.css("display", originalDisplayMode);
+        }
     };
 
     Room.prototype.canTrimHistory = function () {


### PR DESCRIPTION
This attempts to fix #835 by hiding the user list container element using display:none; and then restoring it to its original display value after the sorting of the child nodes is completed.

I also added an explicit length test to see if there were any children even in a particular list (owners vs. activeusers) as a short circuit before doing any more costly operations unecessarily.
