### PR TITLE
Update the lock/readonly icons to use FontAwesome for scaling

### DIFF
--- a/JabbR/Chat.css
+++ b/JabbR/Chat.css
@@ -481,17 +481,15 @@ form#send-message {
     }
 
     .users li.room.locked .lock {
-        position: absolute;
-        width: 16px;
+        position: relative;
+        width: 19px;
         height: 16px;
-        background: url(Content/images/lock.png) no-repeat bottom;
     }
 
     .users li.room.closed .readonly {
-        position: absolute;
+        position: relative;
         width: 19px;
         height: 16px;
-        background: url(Content/images/no-typing.png) no-repeat;
     }
 
     .users li.room.closed.locked .readonly {
@@ -621,7 +619,7 @@ li.user.typing .user-status {
         }
 
         #tabs li.locked .content {
-            margin: 6px 10px 6px 23px;
+            margin: 6px 10px 6px 27px;
         }
 
         #tabs li.closed .content {
@@ -634,48 +632,26 @@ li.user.typing .user-status {
 
         #tabs li .close {
             position: absolute;
-            top: 7px;
-            right: 5px;
+            top: 5px;
+            right: 0;
             width: 16px;
             height: 16px;
-            background: url(Content/images/close-icon.png);
         }
 
         #tabs li.locked .lock {
             position: absolute;
-            top: 7px;
-            width: 16px;
-            height: 16px;
+            top: 5px;
             margin-left: 5px;
-            background: url(Content/images/lockwhite.png) no-repeat;
-        }
-
-        #tabs li.locked.current .lock, #tabs li.locked:hover .lock {
-            background: url(Content/images/lock.png) no-repeat;
         }
 
         #tabs li.closed .readonly {
             position: absolute;
-            top: 7px;
-            width: 19px;
-            height: 16px;
+            top: 5px;
             margin-left: 5px;
-            background: url(Content/images/no-typing-white.png) no-repeat;
-        }
-
-        #tabs li.closed.current .readonly, #tabs li.closed:hover .readonly {
-            background: url(Content/images/no-typing.png) no-repeat;
         }
 
         #tabs li.closed.locked .readonly {
             margin-left: 22px;
-        }
-
-        #tabs li .close:hover {
-            background: url(Content/images/close-icon-hover.png);
-        }
-
-        #tabs li.unread {
         }
 
         #tabs li:hover {

--- a/JabbR/Chat.ui.room.js
+++ b/JabbR/Chat.ui.room.js
@@ -155,11 +155,13 @@
     Room.prototype.close = function () {
         this.tab.attr('data-closed', true);
         this.tab.addClass('closed');
+        this.tab.find('.readonly').removeClass('hide');
     };
 
     Room.prototype.unClose = function () {
         this.tab.attr('data-closed', false);
         this.tab.removeClass('closed');
+        this.tab.find('.readonly').addClass('hide');
     };
 
     Room.prototype.clear = function () {
@@ -231,6 +233,7 @@
 
     Room.prototype.setLocked = function () {
         this.tab.addClass('locked');
+        this.tab.find('.lock').removeClass('hide');
     };
 
     Room.prototype.setListState = function (list) {
@@ -328,18 +331,6 @@
                 $(listItems[i]).after(user);
                 break;
             }
-
-
-            //if (userActive && !otherActive) {
-            //    $(listItems[i]).before(user);
-            //    break;
-            //} else if (userActive === otherActive &&
-            //        userName.toUpperCase() < otherName.toUpperCase()) {
-            //    $(listItems[i]).before(user);
-            //    break;
-            //} else if ((!userActive && otherActive) && i === listItems.length - 1) {
-            //    $(listItems[i]).after(user);
-            //}
         }
     };
 

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -93,7 +93,7 @@
                 <div class="span3">
                     <span class="name">${Name}</span>
                     <span class="lock"><i class="icon-lock"></i></span>
-                    <span class="readonly"><i class="icon-remove-sign"></i></span>
+                    <span class="readonly"><i class="icon-ban-circle"></i></span>
                 </div>
                 <div class="span4">
                     <span class="topic">${Topic}</span>
@@ -134,12 +134,12 @@
     </script>
     <script id="new-tab-template" type="text/x-jquery-tmpl">
         <li id="tabs-${id}" class="room" data-name="${name}" data-closed="${closed}" data-trimmable="true" role="tab">
-            <span class="lock"></span>
-            <span class="readonly"></span>
+            <span class="lock hide"><i class="icon-lock icon-large"></i></span>
+            <span class="readonly hide"><i class="icon-ban-circle icon-large"></i></span>
             <button> 
                 <span class="content">${name}</span>
             </button>
-            <div class="close"></div>
+            <button class="close">&times;</button>
         </li>
     </script>
     <script id="command-help-template" type="text/x-jquery-tmpl">


### PR DESCRIPTION
I had to update the Closed/ReadOnly icon as there isn't a crossed out chat bubble icon in the FontAwesome arsenal, but I believe the ban circle icon conveys the message...let me know if you'd like me to change it :smiley: 

Zoomed to 200% on Non-Retina
![image](https://f.cloud.github.com/assets/1035315/469869/cd0af51e-b6e2-11e2-9815-f8862edb069d.png)

Zoomed to 150% on Non-Retina
![image](https://f.cloud.github.com/assets/1035315/469842/222c3f9a-b6e2-11e2-8153-ebca3298d944.png)

Normal Non-Retina
![image](https://f.cloud.github.com/assets/1035315/469848/33a399e4-b6e2-11e2-86b0-8b6c013ed767.png)

Fixes #840 
