### PR TITLE
Fix encodings of generated room ids to allow unicode

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -98,7 +98,7 @@
     }
 
     function getRoomId(roomName) {
-        return window.escape(roomName.toString().toLowerCase()).replace(/[^a-z0-9]/, '_');
+        return window.escape(roomName.toString().toLowerCase()).replace(/[^A-Za-z0-9]/g, '_');
     }
 
     function getUserClassName(userName) {


### PR DESCRIPTION
Replace all instances of non-alphanumerics in roomnames, allow and handle uppercase alphanumerics in unicode encodings.

Should fix #842
