### PR TITLE
middle click on chat room tab now closes it

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -841,7 +841,7 @@
 
             $document.on('mousedown', '#tabs li', function (ev) {
                 // if middle mouse
-                if (ev.which == 2) {
+                if (ev.which === 2) {
                     $ui.trigger(ui.events.closeRoom, [$(this).data('name')]);
                 }
             });

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -839,6 +839,13 @@
                 ui.setActiveRoom($(this).data('name'));
             });
 
+            $document.on('mousedown', '#tabs li', function (ev) {
+                // if middle mouse
+                if (ev.which == 2) {
+                    $ui.trigger(ui.events.closeRoom, [$(this).data('name')]);
+                }
+            });
+
             $document.on('click', 'li.room .room-row', function () {
                 var roomName = $(this).parent().data('name'),
                     room = getRoomElements(roomName);


### PR DESCRIPTION
When you middle click on the chat room tabs, they now close (the same convention as browser tabs).  Should fix #831
