### PR TITLE
Add allowed command

### DIFF
--- a/JabbR.Tests/CommandManagerFacts.cs
+++ b/JabbR.Tests/CommandManagerFacts.cs
@@ -3362,7 +3362,6 @@ namespace JabbR.Test
                     Name = "room",
                     Private = true,
                     AllowedUsers = new Collection<ChatUser>() { user },
-                    Users = new Collection<ChatUser>() { user }
                 };
                 repository.Add(room);
                 var room2 = new ChatRoom
@@ -3429,46 +3428,6 @@ namespace JabbR.Test
                     Name = "room",
                     Private = true,
                     AllowedUsers = new Collection<ChatUser>() { },
-                    Users = new Collection<ChatUser>() { }
-                };
-                repository.Add(room);
-                var room2 = new ChatRoom
-                {
-                    Name = "room2",
-                    Private = true,
-                    AllowedUsers = new Collection<ChatUser>() { user },
-                    Users = new Collection<ChatUser>() { user }
-                };
-                repository.Add(room2);
-                var service = new ChatService(cache, repository);
-                var notificationService = new Mock<INotificationService>();
-                var commandManager = new CommandManager("clientid",
-                                                        "1",
-                                                        "room2",
-                                                        service,
-                                                        repository,
-                                                        cache,
-                                                        notificationService.Object);
-
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allowed room"));
-            }
-
-            [Fact]
-            public void CannotGetInfoForNonJoinedPrivateRoom()
-            {
-                var repository = new InMemoryRepository();
-                var cache = new Mock<ICache>().Object;
-                var user = new ChatUser
-                {
-                    Name = "dfowler",
-                    Id = "1"
-                };
-                repository.Add(user);
-                var room = new ChatRoom
-                {
-                    Name = "room",
-                    Private = true,
-                    AllowedUsers = new Collection<ChatUser>() { user },
                     Users = new Collection<ChatUser>() { }
                 };
                 repository.Add(room);

--- a/JabbR.Tests/CommandManagerFacts.cs
+++ b/JabbR.Tests/CommandManagerFacts.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace JabbR.Test
 {
+    using System.Collections.ObjectModel;
+
     public class CommandManagerFacts
     {
         public class ParseCommand
@@ -3270,6 +3272,225 @@ namespace JabbR.Test
                 Assert.True(result);
                 notificationService.Verify(x => x.AllowUser(user2, room), Times.Once());
                 Assert.True(room.AllowedUsers.Contains(user2));
+            }
+        }
+
+        public class AllowedCommand
+        {
+            [Fact]
+            public void CanGetAllowedUserListDefault()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var user = new ChatUser
+                {
+                    Name = "dfowler",
+                    Id = "1"
+                };
+                repository.Add(user);
+                var room = new ChatRoom
+                {
+                    Name = "room", 
+                    Private = true, 
+                    AllowedUsers = new Collection<ChatUser>() { user },
+                    Users = new Collection<ChatUser>() { user }
+                };
+                repository.Add(room);
+                var service = new ChatService(cache, repository);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("clientid",
+                                                        "1",
+                                                        "room",
+                                                        service,
+                                                        repository,
+                                                        cache,
+                                                        notificationService.Object);
+
+                bool result = commandManager.TryHandleCommand("/allowed");
+
+                Assert.True(result);
+                notificationService.Verify(x => x.ListAllowedUsers(room), Times.Once());
+            }
+
+            [Fact]
+            public void CanGetAllowedUserListPublicRoom()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var user = new ChatUser
+                {
+                    Name = "dfowler",
+                    Id = "1"
+                };
+                repository.Add(user);
+                var room = new ChatRoom
+                {
+                    Name = "room",
+                    Private = false,
+                    Users = new Collection<ChatUser>() { user }
+                };
+                repository.Add(room);
+                var service = new ChatService(cache, repository);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("clientid",
+                                                        "1",
+                                                        "room",
+                                                        service,
+                                                        repository,
+                                                        cache,
+                                                        notificationService.Object);
+
+                bool result = commandManager.TryHandleCommand("/allowed room");
+
+                Assert.True(result);
+                notificationService.Verify(x => x.ListAllowedUsers(room), Times.Once());
+            }
+
+            [Fact]
+            public void CanGetAllowedUserListSpecified()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var user = new ChatUser
+                {
+                    Name = "dfowler",
+                    Id = "1"
+                };
+                repository.Add(user);
+                var room = new ChatRoom
+                {
+                    Name = "room",
+                    Private = true,
+                    AllowedUsers = new Collection<ChatUser>() { user },
+                    Users = new Collection<ChatUser>() { user }
+                };
+                repository.Add(room);
+                var room2 = new ChatRoom
+                {
+                    Name = "room2",
+                    Private = true,
+                    AllowedUsers = new Collection<ChatUser>() { user },
+                    Users = new Collection<ChatUser>() { user }
+                };
+                repository.Add(room2);
+                var service = new ChatService(cache, repository);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("clientid",
+                                                        "1",
+                                                        "room2",
+                                                        service,
+                                                        repository,
+                                                        cache,
+                                                        notificationService.Object);
+
+                bool result = commandManager.TryHandleCommand("/allowed room");
+
+                Assert.True(result);
+                notificationService.Verify(x => x.ListAllowedUsers(room), Times.Once());
+            }
+            
+            [Fact]
+            public void CannotGetInfoForInvalidRoom()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var user = new ChatUser
+                {
+                    Name = "dfowler",
+                    Id = "1"
+                };
+                repository.Add(user);
+                var service = new ChatService(cache, repository);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("clientid",
+                                                        "1",
+                                                        null,
+                                                        service,
+                                                        repository,
+                                                        cache,
+                                                        notificationService.Object);
+
+                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allowed room3"));
+            }
+
+            [Fact]
+            public void CannotGetInfoForInaccessiblePrivateRoom()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var user = new ChatUser
+                {
+                    Name = "dfowler",
+                    Id = "1"
+                };
+                repository.Add(user);
+                var room = new ChatRoom
+                {
+                    Name = "room",
+                    Private = true,
+                    AllowedUsers = new Collection<ChatUser>() { },
+                    Users = new Collection<ChatUser>() { }
+                };
+                repository.Add(room);
+                var room2 = new ChatRoom
+                {
+                    Name = "room2",
+                    Private = true,
+                    AllowedUsers = new Collection<ChatUser>() { user },
+                    Users = new Collection<ChatUser>() { user }
+                };
+                repository.Add(room2);
+                var service = new ChatService(cache, repository);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("clientid",
+                                                        "1",
+                                                        "room2",
+                                                        service,
+                                                        repository,
+                                                        cache,
+                                                        notificationService.Object);
+
+                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allowed room"));
+            }
+
+            [Fact]
+            public void CannotGetInfoForNonJoinedPrivateRoom()
+            {
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var user = new ChatUser
+                {
+                    Name = "dfowler",
+                    Id = "1"
+                };
+                repository.Add(user);
+                var room = new ChatRoom
+                {
+                    Name = "room",
+                    Private = true,
+                    AllowedUsers = new Collection<ChatUser>() { user },
+                    Users = new Collection<ChatUser>() { }
+                };
+                repository.Add(room);
+                var room2 = new ChatRoom
+                {
+                    Name = "room2",
+                    Private = true,
+                    AllowedUsers = new Collection<ChatUser>() { user },
+                    Users = new Collection<ChatUser>() { user }
+                };
+                repository.Add(room2);
+                var service = new ChatService(cache, repository);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("clientid",
+                                                        "1",
+                                                        "room2",
+                                                        service,
+                                                        repository,
+                                                        cache,
+                                                        notificationService.Object);
+
+                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allowed room"));
             }
         }
 

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -732,6 +732,19 @@
             ui.addMessage(users.join(', '), 'list-item');
         }
     };
+    
+    chat.client.listAllowedUsers = function (room, isPrivate, users) {
+        if (!isPrivate) {
+            ui.addMessage('Anyone is allowed in ' + room + ' as it is not private', 'list-header');
+        }
+        else if (users.length === 0) {
+            ui.addMessage('No users are allowed in ' + room, 'list-header');
+        }
+        else {
+            ui.addMessage('The following users are allowed in ' + room, 'list-header');
+            ui.addMessage(users.join(', '), 'list-item');
+        }
+    };
 
     chat.client.showUsersRoomList = function (user, rooms) {
         var status = "Currently " + user.Status;

--- a/JabbR/Commands/AllowedCommand.cs
+++ b/JabbR/Commands/AllowedCommand.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using JabbR.Models;
+using JabbR.Services;
+
+namespace JabbR.Commands
+{
+    [Command("allowed", "Show a list of all users allowed in the given room.", "[room]", "global")]
+    public class AllowedCommand : UserCommand
+    {
+        public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
+        {
+            string targetRoomName = args.Length > 0 ? args[0] : callerContext.RoomName;
+
+            if (string.IsNullOrEmpty(targetRoomName) || targetRoomName.Equals("Lobby", StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new InvalidOperationException("Which room?");
+            }
+
+            ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, targetRoomName);
+
+            context.NotificationService.ListAllowedUsers(room);
+        }
+    }
+}

--- a/JabbR/Commands/AllowedCommand.cs
+++ b/JabbR/Commands/AllowedCommand.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using JabbR.Models;
-using JabbR.Services;
 
 namespace JabbR.Commands
 {
-    [Command("allowed", "Show a list of all users allowed in the given room.", "[room]", "global")]
+    [Command("allowed", "Show a list of all users allowed in the given room.", "[room]", "room")]
     public class AllowedCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
@@ -16,7 +15,10 @@ namespace JabbR.Commands
                 throw new InvalidOperationException("Which room?");
             }
 
-            ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, targetRoomName);
+            ChatRoom room = context.Repository.VerifyRoom(targetRoomName, mustBeOpen: false);
+
+            // ensure the user could join the room if they wanted to
+            context.Service.EnsureAllowed(callingUser, room);
 
             context.NotificationService.ListAllowedUsers(room);
         }

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -854,6 +854,11 @@ namespace JabbR
             Clients.Caller.showUsersInRoom(room.Name, names);
         }
 
+        void INotificationService.ListAllowedUsers(ChatRoom room)
+        {
+            Clients.Caller.listAllowedUsers(room.Name, room.Private, room.AllowedUsers.Select(s => s.Name));
+        }
+
         void INotificationService.LockRoom(ChatUser targetUser, ChatRoom room)
         {
             var userViewModel = new UserViewModel(targetUser);

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -994,6 +994,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\Startup.DependencyInjection.cs" />
+    <Compile Include="Commands\AllowedCommand.cs" />
     <Compile Include="ContentProviders\Core\ContentProviderProcessor.cs" />
     <Compile Include="ContentProviders\GitHubIssueCommentsContentProvider.cs" />
     <Compile Include="Hubs\LoggingHubPipelineModule.cs" />

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -646,6 +646,14 @@ namespace JabbR.Services
             }
         }
 
+        public void EnsureAllowed(ChatUser user, ChatRoom room)
+        {
+            if (room.Private && !this.IsUserAllowed(room, user))
+            {
+                throw new InvalidOperationException("You do not have access to " + room.Name);
+            }
+        }
+
         public void AllowUser(ChatUser user, ChatUser targetUser, ChatRoom targetRoom)
         {
             EnsureOwnerOrAdmin(user, targetRoom);

--- a/JabbR/Services/IChatService.cs
+++ b/JabbR/Services/IChatService.cs
@@ -15,6 +15,7 @@ namespace JabbR.Services
         void JoinRoom(ChatUser user, ChatRoom room, string inviteCode);
         void LeaveRoom(ChatUser user, ChatRoom room);
         void SetInviteCode(ChatUser user, ChatRoom room, string inviteCode);
+        void EnsureAllowed(ChatUser user, ChatRoom room);
 
         // Messages
         ChatMessage AddMessage(ChatUser user, ChatRoom room, string id, string content);

--- a/JabbR/Services/INotificationService.cs
+++ b/JabbR/Services/INotificationService.cs
@@ -16,6 +16,7 @@ namespace JabbR.Services
         void ListUsers(ChatRoom room, IEnumerable<string> names);
         void ListRooms(ChatUser user);
         void ListUsers(IEnumerable<ChatUser> users);
+        void ListAllowedUsers(ChatRoom room);
 
         void Invite(ChatUser user, ChatUser targetUser, ChatRoom targetRoom);
         void NudgeRoom(ChatRoom room, ChatUser user);


### PR DESCRIPTION
Should fix #849

There are a couple of bits that aren't great - exposing EnsureAllowed on IChatService is probably the worst, and I dunno how good the tests are (they do pass though).

Lets you type /allowed [roomname] where roomname is optional (defaults to the current room).  If you could join the room, it'll list the users who are allowed to join the room (or tell you "Anyone is allowed in general-chat as it is not private" if it's public).
