### PR TITLE
Prevent trying to remove users from the room if they're not already present

### DIFF
--- a/JabbR/Services/PersistedRepository.cs
+++ b/JabbR/Services/PersistedRepository.cs
@@ -196,6 +196,11 @@ namespace JabbR.Services
         {
             RunNonLazy(() =>
             {
+                if (!room.Users.Contains(user))
+                {
+                    return;
+                }
+
                 // The hack from hell to attach the user to room.Users so delete is tracked
                 ObjectContext context = ((IObjectContextAdapter)_db).ObjectContext;
                 RelationshipManager manger = context.ObjectStateManager.GetRelationshipManager(room);


### PR DESCRIPTION
May help mitigate #852, guard against users that aren't present being removed from the list, possibly causing an exception.
