### PR TITLE
Improve room commands

### DIFF
--- a/JabbR.Tests/CommandManagerFacts.cs
+++ b/JabbR.Tests/CommandManagerFacts.cs
@@ -310,7 +310,7 @@ namespace JabbR.Test
                 var notificationService = new Mock<INotificationService>();
                 var commandManager = new CommandManager("clientid",
                                                         "1",
-                                                        null,
+                                                        "room",
                                                         service,
                                                         repository,
                                                         cache,
@@ -323,7 +323,7 @@ namespace JabbR.Test
                 Assert.Equal(6, room.InviteCode.Length);
                 Assert.True(room.InviteCode.All(c => Char.IsDigit(c)));
                 // expect the notification in the lobby (null room)
-                notificationService.Verify(n => n.PostNotification(null, user, String.Format("Invite Code for {0}: {1}", room.Name, room.InviteCode)));
+                notificationService.Verify(n => n.PostNotification(room, user, String.Format("Invite Code for {0}: {1}", room.Name, room.InviteCode)));
             }
 
             [Fact]

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -448,7 +448,7 @@
     };
 
     chat.client.userUnallowed = function (user, room) {
-        ui.addMessage('You have revoked ' + user + '"s access to ' + room, 'notification', this.state.activeRoom);
+        ui.addMessage('You have revoked ' + user + '\'s access to ' + room, 'notification', this.state.activeRoom);
     };
 
     // Called when you make someone an owner

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -448,7 +448,7 @@
     };
 
     chat.client.userUnallowed = function (user, room) {
-        ui.addMessage('You have revoked ' + user + String.fromCharCode(39) + 's access to ' + room, 'notification', this.state.activeRoom);
+        ui.addMessage('You have revoked ' + user + '\'s access to ' + room, 'notification', this.state.activeRoom);
     };
 
     // Called when you make someone an owner

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -448,7 +448,7 @@
     };
 
     chat.client.userUnallowed = function (user, room) {
-        ui.addMessage('You have revoked ' + user + '\'s access to ' + room, 'notification', this.state.activeRoom);
+        ui.addMessage('You have revoked ' + user + String.fromCharCode(39) + 's access to ' + room, 'notification', this.state.activeRoom);
     };
 
     // Called when you make someone an owner

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -773,8 +773,8 @@
             $userCmdHelp = $('#jabbr-help #user');
             $updatePopup = $('#jabbr-update');
             focus = true;
-            $lobbyRoomFilterForm = $('#room-filter-form'),
-            $roomFilterInput = $('#room-filter'),
+            $lobbyRoomFilterForm = $('#room-filter-form');
+            $roomFilterInput = $('#room-filter');
             $closedRoomFilter = $('#room-filter-closed');
             templates = {
                 userlist: $('#new-userlist-template'),

--- a/JabbR/Commands/AddOwnerCommand.cs
+++ b/JabbR/Commands/AddOwnerCommand.cs
@@ -3,7 +3,7 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("addowner", "Add an owner a user as an owner to the specified room. Only works if you're an owner of that room.", "user room", "room")]
+    [Command("addowner", "Add an owner a user as an owner to the specified room. Only works if you're an owner of that room.", "user [room]", "room")]
     public class AddOwnerCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
@@ -17,12 +17,13 @@ namespace JabbR.Commands
 
             ChatUser targetUser = context.Repository.VerifyUser(targetUserName);
 
-            if (args.Length == 1)
+            string roomName = args.Length > 1 ? args[1] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
             {
                 throw new InvalidOperationException("Which room?");
             }
 
-            string roomName = args[1];
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
 
             context.Service.AddOwner(callingUser, targetUser, targetRoom);

--- a/JabbR/Commands/AllowCommand.cs
+++ b/JabbR/Commands/AllowCommand.cs
@@ -3,7 +3,7 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("allow", "Give a user permission to a private room. Only works if you're an owner of that room.", "user room", "room")]
+    [Command("allow", "Give a user permission to a private room. Only works if you're an owner of that room.", "user [room]", "room")]
     public class AllowCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
@@ -17,12 +17,13 @@ namespace JabbR.Commands
 
             ChatUser targetUser = context.Repository.VerifyUser(targetUserName);
 
-            if (args.Length == 1)
+            string roomName = args.Length > 1 ? args[1] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
             {
                 throw new InvalidOperationException("Which room?");
             }
 
-            string roomName = args[1];
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
 
             context.Service.AllowUser(callingUser, targetUser, targetRoom);

--- a/JabbR/Commands/AllowedCommand.cs
+++ b/JabbR/Commands/AllowedCommand.cs
@@ -10,7 +10,7 @@ namespace JabbR.Commands
         {
             string targetRoomName = args.Length > 0 ? args[0] : callerContext.RoomName;
 
-            if (String.IsNullOrEmpty(targetRoomName) || targetRoomName.Equals("Lobby", StringComparison.InvariantCultureIgnoreCase))
+            if (String.IsNullOrEmpty(targetRoomName))
             {
                 throw new InvalidOperationException("Which room?");
             }

--- a/JabbR/Commands/CloseCommand.cs
+++ b/JabbR/Commands/CloseCommand.cs
@@ -4,17 +4,18 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("close", "Close a room. Only works if you're an owner of that room.", "room", "room")]
+    [Command("close", "Close a room. Only works if you're an owner of that room.", "[room]", "room")]
     public class CloseCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
-            if (args.Length == 0)
+            string roomName = args.Length > 0 ? args[0] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
             {
                 throw new InvalidOperationException("Which room do you want to close?");
             }
 
-            string roomName = args[0];
             ChatRoom room = context.Repository.VerifyRoom(roomName);
 
             // Before I close the room, I need to grab a copy of -all- the users in that room.

--- a/JabbR/Commands/InviteCodeCommand.cs
+++ b/JabbR/Commands/InviteCodeCommand.cs
@@ -4,19 +4,30 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("invitecode", "Show the current invite code.", "", "room")]
+    [Command("invitecode", "Show the current invite code.", "[room]", "room")]
     public class InviteCodeCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
-            ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, callerContext.RoomName);
+            string targetRoomName = args.Length > 0 ? args[0] : callerContext.RoomName;
 
-            if (String.IsNullOrEmpty(room.InviteCode))
+            if (String.IsNullOrEmpty(targetRoomName))
             {
-                context.Service.SetInviteCode(callingUser, room, RandomUtils.NextInviteCode());
+                throw new InvalidOperationException("Which room?");
             }
 
-            context.NotificationService.PostNotification(room, callingUser, String.Format("Invite Code for this room: {0}", room.InviteCode));
+            ChatRoom targetRoom = context.Repository.VerifyRoom(targetRoomName, mustBeOpen: false);
+
+            // ensure the user could join the room if they wanted to
+            callingUser.EnsureAllowed(targetRoom);
+
+            if (String.IsNullOrEmpty(targetRoom.InviteCode))
+            {
+                context.Service.SetInviteCode(callingUser, targetRoom, RandomUtils.NextInviteCode());
+            }
+
+            ChatRoom callingRoom = context.Repository.GetRoomByName(callerContext.RoomName);
+            context.NotificationService.PostNotification(callingRoom, callingUser, String.Format("Invite Code for {0}: {1}", targetRoomName, targetRoom.InviteCode));
         }
     }
 }

--- a/JabbR/Commands/InviteCodeCommand.cs
+++ b/JabbR/Commands/InviteCodeCommand.cs
@@ -9,6 +9,11 @@ namespace JabbR.Commands
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
+            if (String.IsNullOrEmpty(callerContext.RoomName))
+            {
+                throw new InvalidOperationException("This command cannot be invoked from the Lobby.");
+            }
+
             string targetRoomName = args.Length > 0 ? args[0] : callerContext.RoomName;
 
             if (String.IsNullOrEmpty(targetRoomName))

--- a/JabbR/Commands/InviteCommand.cs
+++ b/JabbR/Commands/InviteCommand.cs
@@ -3,7 +3,7 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("invite", "Invite a user to join a room.", "user room", "room")]
+    [Command("invite", "Invite a user to join a room.", "user [room]", "room")]
     public class InviteCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
@@ -22,12 +22,13 @@ namespace JabbR.Commands
                 throw new InvalidOperationException("You can't invite yourself!");
             }
 
-            if (args.Length == 1)
+            string roomName = args.Length > 1 ? args[1] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
             {
                 throw new InvalidOperationException("Invite them to which room?");
             }
 
-            string roomName = args[1];
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
 
             context.NotificationService.Invite(callingUser, targetUser, targetRoom);

--- a/JabbR/Commands/KickCommand.cs
+++ b/JabbR/Commands/KickCommand.cs
@@ -1,29 +1,30 @@
 ﻿using System;
-using System.Linq;
 using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("kick", "Kick a user from the room. Note, this is only valid for owners of the room.", "user", "user")]
+    [Command("kick", "Kick a user from the room. Note, this is only valid for owners of the room.", "user [room]", "user")]
     public class KickCommand : UserCommand
     {
-        public override void Execute(CommandContext context, CallerContext callerContext, Models.ChatUser callingUser, string[] args)
+        public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
             if (args.Length == 0)
             {
                 throw new InvalidOperationException("Who are you trying to kick?");
             }
 
-            ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, callerContext.RoomName);
-
-            if (context.Repository.GetOnlineUsers(room).Count() == 1)
-            {
-                throw new InvalidOperationException("You're the only person in here...");
-            }
-
             string targetUserName = args[0];
 
             ChatUser targetUser = context.Repository.VerifyUser(targetUserName);
+
+            string targetRoomName = args.Length > 1 ? args[1] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(targetRoomName))
+            {
+                throw new InvalidOperationException("Which room?");
+            }
+
+            ChatRoom room = context.Repository.VerifyRoom(targetRoomName);
 
             context.Service.KickUser(callingUser, targetUser, room);
 

--- a/JabbR/Commands/LeaveCommand.cs
+++ b/JabbR/Commands/LeaveCommand.cs
@@ -1,4 +1,5 @@
-﻿using JabbR.Models;
+﻿using System;
+using JabbR.Models;
 
 namespace JabbR.Commands
 {
@@ -7,17 +8,14 @@ namespace JabbR.Commands
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
-            ChatRoom room = null;
-            if (args.Length  == 0)
-            {
-                room = context.Repository.VerifyUserRoom(context.Cache, callingUser, callerContext.RoomName);                
-            }
-            else
-            {
-                string roomName = args[0];
+            string targetRoomName = args.Length > 0 ? args[0] : callerContext.RoomName;
 
-                room = context.Repository.VerifyRoom(roomName, mustBeOpen: false);
+            if (String.IsNullOrEmpty(targetRoomName))
+            {
+                throw new InvalidOperationException("Which room?");
             }
+
+            ChatRoom room = context.Repository.VerifyRoom(targetRoomName);
 
             context.Service.LeaveRoom(callingUser, room);
 

--- a/JabbR/Commands/ListCommand.cs
+++ b/JabbR/Commands/ListCommand.cs
@@ -4,18 +4,22 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("list", "Show a list of users in the room.", "room", "room")]
+    [Command("list", "Show a list of users in the room.", "[room]", "room")]
     public class ListCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
-            if (args.Length  == 0)
+            string roomName = args.Length > 0 ? args[0] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
             {
                 throw new InvalidOperationException("List users in which room?");
             }
 
-            string roomName = args[0];
             ChatRoom room = context.Repository.VerifyRoom(roomName);
+
+            // ensure the user could join the room if they wanted to
+            callingUser.EnsureAllowed(room);
 
             var names = context.Repository.GetOnlineUsers(room).Select(s => s.Name);
 

--- a/JabbR/Commands/LockCommand.cs
+++ b/JabbR/Commands/LockCommand.cs
@@ -3,17 +3,18 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("lock", "Make a room private. Only works if you're the creator of that room.", "room", "room")]
+    [Command("lock", "Make a room private. Only works if you're the creator of that room.", "[room]", "room")]
     public class LockCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
-            if (args.Length  == 0)
+            string roomName = args.Length > 0 ? args[0] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
             {
                 throw new InvalidOperationException("Which room do you want to lock?");
             }
 
-            string roomName = args[0];
             ChatRoom room = context.Repository.VerifyRoom(roomName);
 
             context.Service.LockRoom(callingUser, room);

--- a/JabbR/Commands/RemoveOwnerCommand.cs
+++ b/JabbR/Commands/RemoveOwnerCommand.cs
@@ -3,7 +3,7 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("removeowner", "Remove an owner from the specified room. Only works if you're the creator of that room.", "user room", "room")]
+    [Command("removeowner", "Remove an owner from the specified room. Only works if you're the creator of that room.", "user [room]", "room")]
     public class RemoveOwnerCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
@@ -17,12 +17,13 @@ namespace JabbR.Commands
 
             ChatUser targetUser = context.Repository.VerifyUser(targetUserName);
 
-            if (args.Length == 1)
+            string roomName = args.Length > 1 ? args[1] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
             {
                 throw new InvalidOperationException("Which room?");
             }
 
-            string roomName = args[1];
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
 
             context.Service.RemoveOwner(callingUser, targetUser, targetRoom);

--- a/JabbR/Commands/ResetInviteCodeCommand.cs
+++ b/JabbR/Commands/ResetInviteCodeCommand.cs
@@ -4,16 +4,27 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("resetinvitecode", "Reset the current invite code. This will render the previous invite code invalid.", "", "room")]
+    [Command("resetinvitecode", "Reset the current invite code. This will render the previous invite code invalid.", "[room]", "room")]
     public class ResetInviteCodeCommand : UserCommand
     {
-        public override void Execute(CommandContext context, CallerContext callerContext, Models.ChatUser callingUser, string[] args)
+        public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
-            ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, callerContext.RoomName);
+            string targetRoomName = args.Length > 0 ? args[0] : callerContext.RoomName;
 
-            context.Service.SetInviteCode(callingUser, room, RandomUtils.NextInviteCode());
+            if (String.IsNullOrEmpty(targetRoomName))
+            {
+                throw new InvalidOperationException("Which room?");
+            }
 
-            context.NotificationService.PostNotification(room, callingUser, String.Format("Invite Code for this room: {0}", room.InviteCode));
+            ChatRoom targetRoom = context.Repository.VerifyRoom(targetRoomName, mustBeOpen: false);
+
+            // ensure the user could join the room if they wanted to
+            callingUser.EnsureAllowed(targetRoom);
+
+            context.Service.SetInviteCode(callingUser, targetRoom, RandomUtils.NextInviteCode());
+
+            ChatRoom callingRoom = context.Repository.GetRoomByName(callerContext.RoomName);
+            context.NotificationService.PostNotification(callingRoom, callingUser, String.Format("Invite Code for {0}: {1}", targetRoomName, targetRoom.InviteCode));
         }
     }
 }

--- a/JabbR/Commands/ResetInviteCodeCommand.cs
+++ b/JabbR/Commands/ResetInviteCodeCommand.cs
@@ -9,6 +9,11 @@ namespace JabbR.Commands
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
         {
+            if (String.IsNullOrEmpty(callerContext.RoomName))
+            {
+                throw new InvalidOperationException("This command cannot be invoked from the Lobby.");
+            }
+
             string targetRoomName = args.Length > 0 ? args[0] : callerContext.RoomName;
 
             if (String.IsNullOrEmpty(targetRoomName))

--- a/JabbR/Commands/UnAllowCommand.cs
+++ b/JabbR/Commands/UnAllowCommand.cs
@@ -3,7 +3,7 @@ using JabbR.Models;
 
 namespace JabbR.Commands
 {
-    [Command("unallow", "Revoke a user's permission to a private room. Only works if you're an owner of that room.", "user room", "room")]
+    [Command("unallow", "Revoke a user's permission to a private room. Only works if you're an owner of that room.", "user [room]", "room")]
     public class UnAllowCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
@@ -17,12 +17,13 @@ namespace JabbR.Commands
 
             ChatUser targetUser = context.Repository.VerifyUser(targetUserName);
 
-            if (args.Length == 1)
+            string roomName = args.Length > 1 ? args[1] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
             {
                 throw new InvalidOperationException("Which room?");
             }
 
-            string roomName = args[1];
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
 
             context.Service.UnallowUser(callingUser, targetUser, targetRoom);

--- a/JabbR/Commands/WelcomeCommand.cs
+++ b/JabbR/Commands/WelcomeCommand.cs
@@ -4,7 +4,7 @@ using JabbR.Services;
 
 namespace JabbR.Commands
 {
-    [Command("welcome", "Set the room's welcome message. Type welcome to clear the room's welcome message.", "message", "room")]
+    [Command("welcome", "Set the room's welcome message. Type welcome to clear the room's welcome message.", "[message]", "room")]
     public class WelcomeCommand : UserCommand
     {
         public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -823,9 +823,10 @@ namespace JabbR
 
         void INotificationService.PostNotification(ChatRoom room, ChatUser user, string message)
         {
+            string roomName = room == null ? null : room.Name;
             foreach (var client in user.ConnectedClients)
             {
-                Clients.Client(client.Id).postNotification(message, room.Name);
+                Clients.Client(client.Id).postNotification(message, roomName);
             }
         }
 

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -823,10 +823,9 @@ namespace JabbR
 
         void INotificationService.PostNotification(ChatRoom room, ChatUser user, string message)
         {
-            string roomName = room == null ? null : room.Name;
             foreach (var client in user.ConnectedClients)
             {
-                Clients.Client(client.Id).postNotification(message, roomName);
+                Clients.Client(client.Id).postNotification(message, room.Name);
             }
         }
 

--- a/JabbR/Models/ModelExtensions.cs
+++ b/JabbR/Models/ModelExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
 
 namespace JabbR.Models
 {
@@ -18,7 +15,7 @@ namespace JabbR.Models
 
         public static bool IsUserAllowed(this ChatRoom room, ChatUser user)
         {
-            return room.AllowedUsers.Contains(user) || user.IsAdmin;
+            return room.AllowedUsers.Contains(user) || room.Owners.Contains(user) || user.IsAdmin;
         }
     }
 }


### PR DESCRIPTION
[take 2, this time against dev branch]

Make room commands take the room name optionally (default to current room), and handle access slightly more gracefully - using "is the user allowed into the room or owner or admin" rather than "is the user currently in the room" to account for this.
