### PR TITLE
Limit middle click tab header action to tabs for rooms

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -839,7 +839,7 @@
                 ui.setActiveRoom($(this).data('name'));
             });
 
-            $document.on('mousedown', '#tabs li', function (ev) {
+            $document.on('mousedown', '#tabs li.room', function (ev) {
                 // if middle mouse
                 if (ev.which === 2) {
                     $ui.trigger(ui.events.closeRoom, [$(this).data('name')]);


### PR DESCRIPTION
Fix #860 by not attempting to close non-room tabs when you middle-mouse-click on them.
