### PR TITLE
Use full username in message template

### DIFF
--- a/JabbR/Chat.toast.js
+++ b/JabbR/Chat.toast.js
@@ -24,10 +24,10 @@
                 return;
             }
 
-            var toastTitle = message.trimmedName;
+            var toastTitle = utility.trim(message.name, 21);
             // we can reliably show 22 chars
             if (toastTitle.length <= 19) {
-                toastTitle += ' (' + utility.trim(roomName, 19 - message.trimmedName.length) + ')';
+                toastTitle += ' (' + utility.trim(roomName, 19 - toastTitle.length) + ')';
             }
 
             toastRoom = roomName;

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -466,7 +466,6 @@
         var isFromCollapibleContentProvider = isFromCollapsibleContentProvider(message.message),
             collapseContent = shouldCollapseContent(message.message, roomName);
 
-        message.trimmedName = utility.trim(message.name, 21);
         message.when = message.date.formatTime(true);
         message.fulldate = message.date.toLocaleString();
 

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -46,7 +46,7 @@
             <div class="left">
                 {{if showUser}}
                 <img src="https://secure.gravatar.com/avatar/${hash}?s=16&d=mm" class="gravatar" />
-                <div class="name">${trimmedName}</div>
+                <div class="name">${name}</div>
                 {{/if}}
                 <span class="state"></span>
             </div>


### PR DESCRIPTION
Fixes #862 . Truncation isn't necessary because the CSS handles overflow (and adds ellipses)
