### PR TITLE
Prevent ctrl-tab from switching jabbr tab in Firefox

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -904,7 +904,8 @@
             // handle tab cycling - we skip the lobby when cycling
             // handle shift+/ - display help command
             $document.on('keydown', function (ev) {
-                if (ev.keyCode === Keys.Tab && $newMessage.val() === "") {
+                // ctrl + tab event is sent to the page in firefox when the user probably means to change browser tabs
+                if (ev.keyCode === Keys.Tab && !ev.ctrlKey && $newMessage.val() === "") {
                     var current = getCurrentRoomElements(),
                         index = current.tab.index(),
                         tabCount = $tabs.children().length - 1;


### PR DESCRIPTION
In Firefox this event gets sent to javascript as well as handled by the browser, so when a user does this in FF they usually come back to a different room than they left.

Fixes #722
