### PR TITLE
Make webkit toast click focus on the room that generated the notification

### DIFF
--- a/JabbR/Chat.toast.js
+++ b/JabbR/Chat.toast.js
@@ -1,5 +1,5 @@
 ﻿/// <reference path="Scripts/jquery-1.7.js" />
-(function($, utility) {
+(function($, window, utility) {
     "use strict";
 
     var ToastStatus = { Allowed: 0, NotConfigured: 1, Blocked: 2 },
@@ -49,8 +49,11 @@
             chromeToast.onclick = function () {
                 toast.hideToast();
                                 
-                // Trigger the focus event
+                // Trigger the focus events - focus the window, then open the source room
                 $(toast).trigger('toast.focus', [toastRoom]);
+                
+                // We need to grab the ui/ui.events now as it won't exist when the closure is first run
+                $(window.chat.ui).trigger(window.chat.ui.events.openRoom, [toastRoom]);
             };
 
             chromeToast.show();
@@ -92,4 +95,4 @@
         window.chat = {};
     }
     window.chat.toast = toast;
-})(jQuery, window.chat.utility);
+})(jQuery, window, window.chat.utility);

--- a/JabbR/Chat.toast.js
+++ b/JabbR/Chat.toast.js
@@ -49,11 +49,8 @@
             chromeToast.onclick = function () {
                 toast.hideToast();
                                 
-                // Trigger the focus events - focus the window, then open the source room
+                // Trigger the focus events - focus the window and open the source room
                 $(toast).trigger('toast.focus', [toastRoom]);
-                
-                // We need to grab the ui/ui.events now as it won't exist when the closure is first run
-                $(window.chat.ui).trigger(window.chat.ui.events.openRoom, [toastRoom]);
             };
 
             chromeToast.show();

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1057,6 +1057,9 @@
 
             $(toast).bind('toast.focus', function (ev, room) {
                 window.focus();
+
+                // focus on the room
+                $ui.trigger(ui.events.openRoom, [room]);
             });
 
             $downloadIcon.click(function () {


### PR DESCRIPTION
This should fix the remainder of #808.

Not the cleanest fix as chat.ui relies on toast, and toast needs to generate notifications based on events defined in chat.ui targeted to objects in chat.ui.
