### PR TITLE
Make username change not break things

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1585,7 +1585,8 @@
         },
         changeUserName: function (oldName, user, roomName) {
             var room = getRoomElements(roomName),
-                $user = room.getUserReferences(oldName);
+                $user = room.getUserReferences(oldName),
+                $userListUser = room.getUser(oldName);
 
             // Update the user's name
             $user.find('.name').fadeOut('normal', function () {
@@ -1594,7 +1595,7 @@
             });
             $user.data('name', user.Name);
             $user.attr('data-name', user.Name);
-            room.sortLists($user);
+            room.sortLists($userListUser);
         },
         changeGravatar: function (user, roomName) {
             var room = getRoomElements(roomName),


### PR DESCRIPTION
Currently, when you change your username, any rooms that you're in get broken for everyone if you've got messages - #867.  This is due to sorting the messages from the user into the userlist.  This change fixes that.
