### PR TITLE
Added Screencast.com content provider

### DIFF
--- a/JabbR/ContentProviders/ScreencastContentProvider.cs
+++ b/JabbR/ContentProviders/ScreencastContentProvider.cs
@@ -30,7 +30,9 @@ namespace JabbR.ContentProviders
 
         private Task<PageInfo> ExtractFromResponse(ContentProviderHttpRequest request)
         {
-            return Http.GetAsync(request.RequestUri).Then(response =>
+            var builder = new UriBuilder(request.RequestUri) { Scheme = "https" };
+            
+            return Http.GetAsync(builder.Uri).Then(response =>
             {
                 var pageInfo = new PageInfo();
                 using (Stream responseStream = response.GetResponseStream())

--- a/JabbR/ContentProviders/ScreencastContentProvider.cs
+++ b/JabbR/ContentProviders/ScreencastContentProvider.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using HtmlAgilityPack;
 using JabbR.ContentProviders.Core;
 using JabbR.Infrastructure;
+using Nancy.Helpers;
 
 namespace JabbR.ContentProviders
 {
@@ -17,7 +18,9 @@ namespace JabbR.ContentProviders
             {
                 return new ContentProviderResult
                 {
-                    Content = String.Format(ContentFormat, pageInfo.ImageURL, pageInfo.Title),
+                    Content = String.Format(ContentFormat, 
+					                        HttpUtility.HtmlAttributeEncode(pageInfo.ImageURL), 
+					                        HttpUtility.HtmlAttributeEncode(pageInfo.Title)),
                     Title = pageInfo.Title
                 };
             });
@@ -30,6 +33,7 @@ namespace JabbR.ContentProviders
 
         private Task<PageInfo> ExtractFromResponse(ContentProviderHttpRequest request)
         {
+            //Force https for the url
             var builder = new UriBuilder(request.RequestUri) { Scheme = "https" };
             
             return Http.GetAsync(builder.Uri).Then(response =>

--- a/JabbR/ContentProviders/ScreencastContentProvider.cs
+++ b/JabbR/ContentProviders/ScreencastContentProvider.cs
@@ -5,7 +5,7 @@ using HtmlAgilityPack;
 using JabbR.ContentProviders.Core;
 using JabbR.Infrastructure;
 
-namespace JabbR
+namespace JabbR.ContentProviders
 {
     public class ScreencastContentProvider : CollapsibleContentProvider
     {

--- a/JabbR/ContentProviders/ScreencastContentProvider.cs
+++ b/JabbR/ContentProviders/ScreencastContentProvider.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using HtmlAgilityPack;
+using JabbR.ContentProviders.Core;
+using JabbR.Infrastructure;
+
+namespace JabbR
+{
+    public class ScreencastContentProvider : CollapsibleContentProvider
+    {
+        private static readonly string ContentFormat = "<img src=\"{0}\" alt=\"{1}\" />";
+
+        protected override Task<ContentProviderResult> GetCollapsibleContent(ContentProviderHttpRequest request)
+        {
+            return ExtractFromResponse(request).Then(pageInfo =>
+            {
+                return new ContentProviderResult
+                {
+                    Content = String.Format(ContentFormat, pageInfo.ImageURL, pageInfo.Title),
+                    Title = pageInfo.Title
+                };
+            });
+        }
+
+        public override bool IsValidContent(Uri uri)
+        {
+            return uri.Host.IndexOf("screencast.com", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private Task<PageInfo> ExtractFromResponse(ContentProviderHttpRequest request)
+        {
+            return Http.GetAsync(request.RequestUri).Then(response =>
+            {
+                var pageInfo = new PageInfo();
+                using (Stream responseStream = response.GetResponseStream())
+                {
+                    var htmlDocument = new HtmlDocument();
+                    htmlDocument.Load(responseStream);
+
+                    HtmlNode title = htmlDocument.DocumentNode.SelectSingleNode("//title");
+                    HtmlNode imageURL = htmlDocument.DocumentNode.SelectSingleNode("//img[@class='embeddedObject']");
+                    pageInfo.Title = title != null ? title.InnerText : String.Empty;
+                    pageInfo.ImageURL = imageURL != null ? imageURL.Attributes["src"].Value : String.Empty;
+                }
+
+                return pageInfo;
+            });
+        }
+
+        private class PageInfo
+        {
+            public string Title { get; set; }
+            public string ImageURL { get; set; }
+        }
+    }
+}

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -1357,6 +1357,7 @@
     <Compile Include="ViewModels\MessageViewModel.cs" />
     <Compile Include="ViewModels\RoomViewModel.cs" />
     <Compile Include="ViewModels\UserViewModel.cs" />
+    <Compile Include="ContentProviders\ScreencastContentProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config">


### PR DESCRIPTION
This adds the ability to show images from Screencast.com (often uploaded with a tool called snagit) as a content provider.

An example url/image: http://www.screencast.com/t/VzUgRVW9yMr8
