### PR TITLE
Improve consistency of behavior around closed rooms

### DIFF
--- a/JabbR/Commands/AllowCommand.cs
+++ b/JabbR/Commands/AllowCommand.cs
@@ -24,7 +24,7 @@ namespace JabbR.Commands
                 throw new InvalidOperationException("Which room?");
             }
 
-            ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
+            ChatRoom targetRoom = context.Repository.VerifyRoom(roomName, mustBeOpen: false);
 
             context.Service.AllowUser(callingUser, targetUser, targetRoom);
 

--- a/JabbR/Commands/InviteCommand.cs
+++ b/JabbR/Commands/InviteCommand.cs
@@ -29,7 +29,7 @@ namespace JabbR.Commands
                 throw new InvalidOperationException("Invite them to which room?");
             }
 
-            ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
+            ChatRoom targetRoom = context.Repository.VerifyRoom(roomName, mustBeOpen: false);
 
             context.NotificationService.Invite(callingUser, targetUser, targetRoom);
         }

--- a/JabbR/Commands/LockCommand.cs
+++ b/JabbR/Commands/LockCommand.cs
@@ -15,7 +15,7 @@ namespace JabbR.Commands
                 throw new InvalidOperationException("Which room do you want to lock?");
             }
 
-            ChatRoom room = context.Repository.VerifyRoom(roomName);
+            ChatRoom room = context.Repository.VerifyRoom(roomName, mustBeOpen: false);
 
             context.Service.LockRoom(callingUser, room);
 

--- a/JabbR/Commands/MeCommand.cs
+++ b/JabbR/Commands/MeCommand.cs
@@ -11,6 +11,8 @@ namespace JabbR.Commands
         {
             ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, callerContext.RoomName);
 
+            room.EnsureOpen();
+
             if (args.Length  == 0)
             {
                 throw new InvalidOperationException("You what?");

--- a/JabbR/Commands/NudgeCommand.cs
+++ b/JabbR/Commands/NudgeCommand.cs
@@ -23,6 +23,8 @@ namespace JabbR.Commands
         {
             ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, callerContext.RoomName);
 
+            room.EnsureOpen();
+
             var betweenNudges = TimeSpan.FromMinutes(1);
             if (room.LastNudged == null || room.LastNudged < DateTime.Now.Subtract(betweenNudges))
             {

--- a/JabbR/Commands/TopicCommand.cs
+++ b/JabbR/Commands/TopicCommand.cs
@@ -17,6 +17,8 @@ namespace JabbR.Commands
 
             ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, callerContext.RoomName);
 
+            room.EnsureOpen();
+
             context.Service.ChangeTopic(callingUser, room, newTopic);
 
             context.NotificationService.ChangeTopic(callingUser, room);

--- a/JabbR/Commands/UnAllowCommand.cs
+++ b/JabbR/Commands/UnAllowCommand.cs
@@ -24,7 +24,7 @@ namespace JabbR.Commands
                 throw new InvalidOperationException("Which room?");
             }
 
-            ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
+            ChatRoom targetRoom = context.Repository.VerifyRoom(roomName, mustBeOpen: false);
 
             context.Service.UnallowUser(callingUser, targetUser, targetRoom);
 

--- a/JabbR/Commands/WelcomeCommand.cs
+++ b/JabbR/Commands/WelcomeCommand.cs
@@ -15,6 +15,9 @@ namespace JabbR.Commands
             newWelcome = String.IsNullOrWhiteSpace(newWelcome) ? null : newWelcome;
 
             ChatRoom room = context.Repository.VerifyUserRoom(context.Cache, callingUser, callerContext.RoomName);
+
+            room.EnsureOpen();
+
             context.Service.ChangeWelcome(callingUser, room, newWelcome);
             context.NotificationService.ChangeWelcome(callingUser, room);
         }

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -159,15 +159,14 @@ namespace JabbR
             var userId = Context.User.GetUserId();
 
             ChatUser user = _repository.VerifyUserId(userId);
-            ChatRoom room = _repository.VerifyUserRoom(_cache, user, clientMessage.Room);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, clientMessage.Room, mustBeOpen: false);
 
             if (room == null || (room.Private && !user.AllowedRooms.Contains(room)))
             {
                 return false;
             }
 
-            // REVIEW: Is it better to use _repository.VerifyRoom(message.Room, mustBeOpen: false)
-            // here?
+            // REVIEW: Is it better to use _repository.VerifyUserRoom(..., mustBeOpen: true) here?
             if (room.Closed)
             {
                 throw new InvalidOperationException(String.Format("You cannot post messages to '{0}'. The room is closed.", clientMessage.Room));
@@ -428,7 +427,7 @@ namespace JabbR
             string userId = Context.User.GetUserId();
 
             ChatUser user = _repository.GetUserById(userId);
-            ChatRoom room = _repository.VerifyUserRoom(_cache, user, notification.Room);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, notification.Room, mustBeOpen: false);
 
             // User must be an owner
             if (room == null ||
@@ -471,7 +470,7 @@ namespace JabbR
             string userId = Context.User.GetUserId();
 
             ChatUser user = _repository.GetUserById(userId);
-            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName, mustBeOpen: false);
 
             if (room == null || (room.Private && !user.AllowedRooms.Contains(room)))
             {

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -159,14 +159,14 @@ namespace JabbR
             var userId = Context.User.GetUserId();
 
             ChatUser user = _repository.VerifyUserId(userId);
-            ChatRoom room = _repository.VerifyUserRoom(_cache, user, clientMessage.Room, mustBeOpen: false);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, clientMessage.Room);
 
             if (room == null || (room.Private && !user.AllowedRooms.Contains(room)))
             {
                 return false;
             }
 
-            // REVIEW: Is it better to use _repository.VerifyUserRoom(..., mustBeOpen: true) here?
+            // REVIEW: Is it better to use the extension method room.EnsureOpen here?
             if (room.Closed)
             {
                 throw new InvalidOperationException(String.Format("You cannot post messages to '{0}'. The room is closed.", clientMessage.Room));
@@ -427,7 +427,7 @@ namespace JabbR
             string userId = Context.User.GetUserId();
 
             ChatUser user = _repository.GetUserById(userId);
-            ChatRoom room = _repository.VerifyUserRoom(_cache, user, notification.Room, mustBeOpen: false);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, notification.Room);
 
             // User must be an owner
             if (room == null ||
@@ -470,7 +470,7 @@ namespace JabbR
             string userId = Context.User.GetUserId();
 
             ChatUser user = _repository.GetUserById(userId);
-            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName, mustBeOpen: false);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName);
 
             if (room == null || (room.Private && !user.AllowedRooms.Contains(room)))
             {

--- a/JabbR/Models/ModelExtensions.cs
+++ b/JabbR/Models/ModelExtensions.cs
@@ -17,5 +17,13 @@ namespace JabbR.Models
         {
             return room.AllowedUsers.Contains(user) || room.Owners.Contains(user) || user.IsAdmin;
         }
+
+        public static void EnsureOpen(this ChatRoom room)
+        {
+            if (room.Closed)
+            {
+                throw new InvalidOperationException(string.Format("The room '{0}' is closed", room.Name));
+            }
+        }
     }
 }

--- a/JabbR/Models/RepositoryExtensions.cs
+++ b/JabbR/Models/RepositoryExtensions.cs
@@ -40,7 +40,7 @@ namespace JabbR.Models
                    select r;
         }
 
-        public static ChatRoom VerifyUserRoom(this IJabbrRepository repository, ICache cache, ChatUser user, string roomName, bool mustBeOpen = true)
+        public static ChatRoom VerifyUserRoom(this IJabbrRepository repository, ICache cache, ChatUser user, string roomName)
         {
             if (String.IsNullOrEmpty(roomName))
             {
@@ -59,11 +59,6 @@ namespace JabbR.Models
             if (!repository.IsUserInRoom(cache, user, room))
             {
                 throw new InvalidOperationException(String.Format("You're not in '{0}'. Use '/join {0}' to join it.", roomName));
-            }
-
-            if (room.Closed && mustBeOpen)
-            {
-                throw new InvalidOperationException(String.Format("The room '{0}' is closed", roomName));
             }
 
             return room;

--- a/JabbR/Models/RepositoryExtensions.cs
+++ b/JabbR/Models/RepositoryExtensions.cs
@@ -40,7 +40,7 @@ namespace JabbR.Models
                    select r;
         }
 
-        public static ChatRoom VerifyUserRoom(this IJabbrRepository repository, ICache cache, ChatUser user, string roomName)
+        public static ChatRoom VerifyUserRoom(this IJabbrRepository repository, ICache cache, ChatUser user, string roomName, bool mustBeOpen = true)
         {
             if (String.IsNullOrEmpty(roomName))
             {
@@ -59,6 +59,11 @@ namespace JabbR.Models
             if (!repository.IsUserInRoom(cache, user, room))
             {
                 throw new InvalidOperationException(String.Format("You're not in '{0}'. Use '/join {0}' to join it.", roomName));
+            }
+
+            if (room.Closed && mustBeOpen)
+            {
+                throw new InvalidOperationException(String.Format("The room '{0}' is closed", roomName));
             }
 
             return room;

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -424,9 +424,9 @@ namespace JabbR.Services
         public ChatMessage AddMessage(string userId, string roomName, string content)
         {
             ChatUser user = _repository.VerifyUserId(userId);
-            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName, mustBeOpen: false);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName);
 
-            // REVIEW: Is it better to use _repository.VerifyUserRoom(..., mustBeOpen: true) here?
+            // REVIEW: Is it better to use room.EnsureOpen() here?
             if (room.Closed)
             {
                 throw new InvalidOperationException(String.Format("You cannot post messages to '{0}'. The room is closed.", roomName));

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -424,10 +424,9 @@ namespace JabbR.Services
         public ChatMessage AddMessage(string userId, string roomName, string content)
         {
             ChatUser user = _repository.VerifyUserId(userId);
-            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName);
+            ChatRoom room = _repository.VerifyUserRoom(_cache, user, roomName, mustBeOpen: false);
 
-            // REVIEW: Is it better to use _repository.VerifyRoom(message.Room, mustBeOpen: false)
-            // here?
+            // REVIEW: Is it better to use _repository.VerifyUserRoom(..., mustBeOpen: true) here?
             if (room.Closed)
             {
                 throw new InvalidOperationException(String.Format("You cannot post messages to '{0}'. The room is closed.", roomName));


### PR DESCRIPTION
At current, closed rooms allow you to enter them with an invite code, however allow, invite, lock, unallow do now work for closed rooms.  This PR makes those base-level user-control functions available.

Note that things that affect users IN the room are unavailable.  Owners cannot be added or removed.

The big part of this change is the change to IJabbrRepository.VerifyUserInRoom to add the optional mustBeOpen parameter.  This is called by the me, nudge, topic, welcome commands, as well as from the chat hub and chatservice.  For the service and hub, the call sites have been updated to include mustBeOpen: false.  For the four commands, previously users could set those (even if it wasn't possible without messing with the UI), now they cannot.

I've added a bunch of tests to exercise this functionality.
