### PR TITLE
Improve consistency of InvalidOperationException messages

### DIFF
--- a/JabbR.Tests/CommandManagerFacts.cs
+++ b/JabbR.Tests/CommandManagerFacts.cs
@@ -4824,7 +4824,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow"));
-                Assert.Equal("Which user to you want to revoke permissions from?", ex.Message);
+                Assert.Equal("Who you want to revoke access permissions from?", ex.Message);
             }
 
             [Fact]
@@ -4880,7 +4880,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2"));
-                Assert.Equal("Which room do you want to the user's access permissions from?", ex.Message);
+                Assert.Equal("Which room do you want to revoke access from?", ex.Message);
             }
 
             [Fact]

--- a/JabbR.Tests/CommandManagerFacts.cs
+++ b/JabbR.Tests/CommandManagerFacts.cs
@@ -152,7 +152,8 @@ namespace JabbR.Test
                 repository.Add(room);
                 var commandManager = new CommandManager("1", "1", "room", service, repository, cache, notificationService.Object);
 
-                Assert.Throws<InvalidOperationException> (() => commandManager.TryHandleCommand ("/message"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/message"));
+                Assert.Equal("'message' is not a valid command.", ex.Message);
             }
 
             [Fact]
@@ -179,7 +180,8 @@ namespace JabbR.Test
                 repository.Add(room);
                 var commandManager = new CommandManager("1", "1", "room", service, repository, cache, notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/a"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/a"));
+                Assert.True(ex.Message.StartsWith("'a' is ambiguous: "));
             }
 
             [Fact]
@@ -284,7 +286,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invitecode"));
-                Assert.Equal("Only private rooms can have invite codes", ex.Message);
+                Assert.Equal("Only private rooms can have invite codes.", ex.Message);
             }
 
             [Fact]
@@ -355,7 +357,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                VerifyThrows<InvalidOperationException>("/invitecode");
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invitecode"));
+                Assert.Equal("This command cannot be invoked from the Lobby.", ex.Message);
             }
 
             [Fact]
@@ -603,7 +606,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invitecode"));
-                Assert.Equal("You do not have access to " + roomName, ex.Message);
+                Assert.Equal("You do not have access to " + roomName + ".", ex.Message);
             }
 
             [Fact]
@@ -638,7 +641,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invitecode"));
-                Assert.Equal("You are not an owner of room '" + roomName + "'", ex.Message);
+                Assert.Equal("You are not an owner of room '" + roomName + "'.", ex.Message);
             }
 
             [Fact]
@@ -673,7 +676,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/resetinvitecode"));
-                Assert.Equal("You do not have access to " + roomName, ex.Message);
+                Assert.Equal("You do not have access to " + roomName + ".", ex.Message);
             }
 
             [Fact]
@@ -709,7 +712,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/resetinvitecode"));
-                Assert.Equal("You are not an owner of room '" + roomName + "'", ex.Message);
+                Assert.Equal("You are not an owner of room '" + roomName + "'.", ex.Message);
             }
         }
 
@@ -812,7 +815,8 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/join"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/join"));
+                Assert.Equal("Which room do you want to join?", ex.Message);
             }
 
             [Fact]
@@ -1038,7 +1042,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/addowner "));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/addowner "));
+                Assert.Equal("Who do you want to make an owner?", ex.Message);
             }
 
             [Fact]
@@ -1062,7 +1067,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/addowner dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/addowner dfowler"));
+                Assert.Equal("Which room do you want to add ownership to?", ex.Message);
             }
 
             [Fact]
@@ -1144,7 +1150,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/addowner dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/addowner dfowler2"));
+                Assert.Equal("The room 'test' is closed.", ex.Message);
             }
 
             [Fact]
@@ -1214,7 +1221,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/removeowner "));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/removeowner "));
+                Assert.Equal("Which owner do you want to remove?", ex.Message);
             }
 
             [Fact]
@@ -1238,7 +1246,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/removeowner dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/removeowner dfowler"));
+                Assert.Equal("Which room do you want to remove the owner from?", ex.Message);
             }
 
             [Fact]
@@ -1372,7 +1381,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/removeowner dfowler2 test"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/removeowner dfowler2 test"));
+                Assert.Equal("The room 'test' is closed.", ex.Message);
             }
 
             [Fact]
@@ -1412,7 +1422,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/removeowner dfowler2 test"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/removeowner dfowler2 test"));
+                Assert.Equal("You are not the creator of room 'test'.", ex.Message);
             }
         }
 
@@ -1439,7 +1450,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/create "));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/create "));
+                Assert.Equal("No room specified.", ex.Message);
             }
 
             [Fact]
@@ -1463,7 +1475,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("create", new string[] { "", "" }));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("create", new [] { "", "" }));
+                Assert.Equal("Room names cannot contain spaces.", ex.Message);
             }
 
             [Fact]
@@ -1492,7 +1505,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/create Test"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/create Test"));
+                Assert.Equal("The room 'Test' already exists.", ex.Message);
             }
 
             [Fact]
@@ -1516,7 +1530,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/create Test Room"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/create Test Room"));
+                Assert.Equal("Room names cannot contain spaces.", ex.Message);
             }
 
             [Fact]
@@ -1552,7 +1567,7 @@ namespace JabbR.Test
 
                 // Act & Assert.
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/create " + roomName));
-                Assert.Equal("The room '" + roomName + "' already exists but it's closed", ex.Message);
+                Assert.Equal("The room '" + roomName + "' already exists but it's closed.", ex.Message);
             }
 
             [Fact]
@@ -1607,7 +1622,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/gravatar "));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/gravatar "));
+                Assert.Equal("Which email address do you want to use for the Gravatar image?", ex.Message);
             }
 
             [Fact]
@@ -1726,7 +1742,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
                 // Act & Assert.
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/note " + note));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/note " + note));
+                Assert.Equal("Sorry, but your note is too long. Please keep it under 140 characters.", ex.Message);
             }
         }
 
@@ -1815,7 +1832,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
                 // Act & Assert.
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/afk " + note));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/afk " + note));
+                Assert.Equal("Sorry, but your note is too long. Please keep it under 140 characters.", ex.Message);
             }
         }
 
@@ -1880,7 +1898,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick"));
+                Assert.Equal("Who do you want to to kick?", ex.Message);
             }
 
             [Fact]
@@ -1920,7 +1939,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick cjm1"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick cjm1"));
+                Assert.Equal("Which room do you want to kick them from?", ex.Message);
             }
 
             [Fact]
@@ -2013,7 +2033,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick fowler3"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick fowler3"));
+                Assert.Equal("Unable to find user 'fowler3'.", ex.Message);
             }
 
             [Fact]
@@ -2059,7 +2080,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler3"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler3"));
+                Assert.Equal("'dfowler3' isn't in 'room'.", ex.Message);
             }
 
             [Fact]
@@ -2161,7 +2183,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler3 room"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler3 room"));
+                Assert.Equal("The room 'room' is closed.", ex.Message);
             }
 
             [Fact]
@@ -2201,7 +2224,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler"));
+                Assert.Equal("Why would you want to kick yourself?", ex.Message);
             }
 
             [Fact]
@@ -2241,7 +2265,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler"));
+                Assert.Equal("You are not an owner of room 'room'.", ex.Message);
             }
 
             [Fact]
@@ -2283,7 +2308,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/kick dfowler"));
+                Assert.Equal("Owners cannot kick other owners. Only the room creator can kick an owner.", ex.Message);
             }
 
             [Fact]
@@ -2368,7 +2394,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/ban"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/ban"));
+                Assert.Equal("Who do you want to ban?", ex.Message);
             }
 
             [Fact]
@@ -2453,7 +2480,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/ban fowler3"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/ban fowler3"));
+                Assert.Equal("Unable to find user 'fowler3'.", ex.Message);
             }
 
             [Fact]
@@ -2496,7 +2524,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/ban dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/ban dfowler2"));
+                Assert.Equal("You cannot ban another admin.", ex.Message);
             }
 
             [Fact]
@@ -2530,7 +2559,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/ban dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/ban dfowler"));
+                Assert.Equal("You cannot ban another admin.", ex.Message);
             }
         }
 
@@ -2646,7 +2676,7 @@ namespace JabbR.Test
             }
 
             [Fact]
-            public void CannotLeaveRoomIfNotImRoom()
+            public void CannotLeaveRoomIfNotInRoom()
             {
                 var repository = new InMemoryRepository();
                 var cache = new Mock<ICache>().Object;
@@ -2673,7 +2703,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/leave"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/leave"));
+                Assert.Equal("Which room do you want to leave?", ex.Message);
             }
         }
 
@@ -2700,7 +2731,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/list"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/list"));
+                Assert.Equal("Which room do you want to list the current users of?", ex.Message);
             }
 
             [Fact]
@@ -2724,7 +2756,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/list test"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/list test"));
+                Assert.Equal("Unable to find room 'test'.", ex.Message);
             }
 
             [Fact]
@@ -2873,7 +2906,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/list room"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/list room"));
+                Assert.Equal("The room 'room' is closed.", ex.Message);
             }
         }
 
@@ -2907,7 +2941,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/me"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/me"));
+                Assert.Equal("You what?", ex.Message);
             }
 
             [Fact]
@@ -2938,7 +2973,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/me is testing"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/me is testing"));
+                Assert.Equal("Use '/join room' to join a room.", ex.Message);
             }
 
             [Fact]
@@ -3004,7 +3040,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/me is testing"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/me is testing"));
+                Assert.Equal("The room 'room' is closed.", ex.Message);
             }
         }
 
@@ -3031,7 +3068,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg"));
+                Assert.Equal("You're the only person in here...", ex.Message);
             }
 
             [Fact]
@@ -3062,7 +3100,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg"));
+                Assert.Equal("Who do you want to send a private message to?", ex.Message);
             }
 
             [Fact]
@@ -3092,7 +3131,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg dfowler3"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg dfowler3"));
+                Assert.Equal("Unable to find user 'dfowler3'.", ex.Message);
             }
 
             [Fact]
@@ -3122,7 +3162,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg dfowler"));
+                Assert.Equal("You can't private message yourself!", ex.Message);
             }
 
             [Fact]
@@ -3152,7 +3193,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg dfowler2 "));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/msg dfowler2 "));
+                Assert.Equal("What do you want to say to 'dfowler2'?", ex.Message);
             }
 
             [Fact]
@@ -3212,7 +3254,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite"));
+                Assert.Equal("Who do you want to invite?", ex.Message);
             }
 
             [Fact]
@@ -3236,7 +3279,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite dfowler2"));
+                Assert.Equal("Unable to find user 'dfowler2'.", ex.Message);
             }
 
             [Fact]
@@ -3266,7 +3310,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite dfowler2"));
+                Assert.Equal("Which room do you want to invite them to?", ex.Message);
             }
 
             [Fact]
@@ -3330,7 +3375,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite dfowler2 asfasfdsad"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite dfowler2 asfasfdsad"));
+                Assert.Equal("Unable to find room 'asfasfdsad'.", ex.Message);
             }
 
             [Fact]
@@ -3361,7 +3407,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite void"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite void"));
+                Assert.Equal("Unable to find user 'void'.", ex.Message);
             }
 
             [Fact]
@@ -3391,7 +3438,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/invite dfowler"));
+                Assert.Equal("You can't invite yourself!", ex.Message);
             }
         }
 
@@ -3425,7 +3473,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge void"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge void"));
+                Assert.Equal("You're the only person in here...", ex.Message);
             }
 
             [Fact]
@@ -3455,7 +3504,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge void"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge void"));
+                Assert.Equal("Unable to find user 'void'.", ex.Message);
             }
 
             [Fact]
@@ -3485,7 +3535,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge dfowler"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge dfowler"));
+                Assert.Equal("You can't nudge yourself!", ex.Message);
             }
 
             [Fact]
@@ -3519,7 +3570,8 @@ namespace JabbR.Test
 
                 Assert.True(result);
                 notificationService.Verify(x => x.NugeUser(user, user2), Times.Once());
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge dfowler2"));
+                Assert.Equal("User can only be nudged once every 60 seconds.", ex.Message);
             }
 
             [Fact]
@@ -3643,7 +3695,8 @@ namespace JabbR.Test
                 notificationService.Verify(x => x.NudgeRoom(room, user), Times.Once());
                 Assert.NotNull(room.LastNudged);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge"));
+                Assert.Equal("Room can only be nudged once every 60 seconds.", ex.Message);
             }
 
             [Fact]
@@ -3684,7 +3737,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/nudge"));
+                Assert.Equal("The room 'room' is closed.", ex.Message);
             }
         }
 
@@ -3765,7 +3819,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/who sethwebster"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/who sethwebster"));
+                Assert.Equal("We didn't find anyone with the username sethwebster.", ex.Message);
             }
         }
 
@@ -3792,7 +3847,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/where"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/where"));
+                Assert.Equal("Who do you want to locate?", ex.Message);
             }
 
             [Fact]
@@ -3816,7 +3872,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/where dfow"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/where dfow"));
+                Assert.Equal("Unable to find user 'dfow'.", ex.Message);
             }
 
             [Fact]
@@ -3871,7 +3928,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow"));
+                Assert.Equal("Who do you want to grant access permissions to?", ex.Message);
             }
 
             [Fact]
@@ -3895,7 +3953,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow dfowler2"));
+                Assert.Equal("Unable to find user 'dfowler2'.", ex.Message);
             }
 
             [Fact]
@@ -3925,7 +3984,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow dfowler2"));
+                Assert.Equal("Which room do you want to allow access to?", ex.Message);
             }
 
             [Fact]
@@ -3955,7 +4015,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow dfowler2 asfasfdsad"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow dfowler2 asfasfdsad"));
+                Assert.Equal("Unable to find room 'asfasfdsad'.", ex.Message);
             }
 
             [Fact]
@@ -3992,7 +4053,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow dfowler2 room"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allow dfowler2 room"));
+                Assert.Equal("room is not a private room.", ex.Message);
             }
 
             [Fact]
@@ -4300,7 +4362,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allowed room3"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allowed room3"));
+                Assert.Equal("Unable to find room 'room3'.", ex.Message);
             }
 
             [Fact]
@@ -4340,7 +4403,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allowed room"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/allowed room"));
+                Assert.Equal("You do not have access to room.", ex.Message);
             }
         }
 
@@ -4367,7 +4431,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/lock"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/lock"));
+                Assert.Equal("Which room do you want to lock?", ex.Message);
             }
 
             [Fact]
@@ -4428,7 +4493,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/lock room"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/lock room"));
+                Assert.Equal("Unable to find room 'room'.", ex.Message);
             }
 
             [Fact]
@@ -4601,7 +4667,7 @@ namespace JabbR.Test
                 // Act & Assert.
                 const string roomName = "ruroh";
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/close " + roomName));
-                Assert.Equal("Unable to find room '" + roomName + "'", ex.Message);
+                Assert.Equal("Unable to find room '" + roomName + "'.", ex.Message);
             }
 
             [Fact]
@@ -4636,7 +4702,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/close " + roomName));
-                Assert.Equal("You are not an owner of room '" + roomName + "'", ex.Message);
+                Assert.Equal("You are not an owner of room '" + roomName + "'.", ex.Message);
             }
 
             [Fact]
@@ -4757,7 +4823,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow"));
+                Assert.Equal("Which user to you want to revoke permissions from?", ex.Message);
             }
 
             [Fact]
@@ -4781,7 +4848,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2"));
+                Assert.Equal("Unable to find user 'dfowler2'.", ex.Message);
             }
 
             [Fact]
@@ -4811,7 +4879,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2"));
+                Assert.Equal("Which room do you want to the user's access permissions from?", ex.Message);
             }
 
             [Fact]
@@ -4885,8 +4954,10 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2 asfasfdsad"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2 asfasfdsad"));
+                Assert.Equal("Unable to find room 'asfasfdsad'.", ex.Message);
             }
+
             [Fact]
             public void CannotUnAllowUserToRoomIfNotPrivate()
             {
@@ -4923,7 +4994,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
 
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2 room"));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/unallow dfowler2 room"));
+                Assert.Equal("room is not a private room.", ex.Message);
             }
 
             [Fact]
@@ -5130,7 +5202,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
                 // Act and Assert
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/flag " + isoCode));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/flag " + isoCode));
+                Assert.Equal("Sorry, but the country ISO code you requested doesn't exist. Please refer to http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 for a proper list of country ISO codes.", ex.Message);
             }
 
             [Fact]
@@ -5156,7 +5229,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
                 // Act and Assert
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/flag " + isoCode));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/flag " + isoCode));
+                Assert.Equal("Sorry, but the country ISO code you requested doesn't exist. Please refer to http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 for a proper list of country ISO codes.", ex.Message);
             }
         }
 
@@ -5236,7 +5310,7 @@ namespace JabbR.Test
                 // Act & Assert.
                 const string roomName = "ruroh";
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/open " + roomName));
-                Assert.Equal("Unable to find room '" + roomName + "'", ex.Message);
+                Assert.Equal("Unable to find room '" + roomName + "'.", ex.Message);
             }
 
             [Fact]
@@ -5306,7 +5380,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/open " + roomName));
-                Assert.Equal("You are not an owner of room '" + roomName + "'", ex.Message);
+                Assert.Equal("You are not an owner of room '" + roomName + "'.", ex.Message);
             }
 
             [Fact]
@@ -5380,7 +5454,7 @@ namespace JabbR.Test
                 string topicLine = "This is the room's topic";
                 var exception = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/topic " + topicLine));
 
-                Assert.Equal("You are not an owner of room 'room'", exception.Message);    
+                Assert.Equal("You are not an owner of room 'room'.", exception.Message);    
             }
 
             [Fact]
@@ -5447,7 +5521,8 @@ namespace JabbR.Test
                                                         cache,
                                                         notificationService.Object);
                 string topicLine = "This is the room's topic";
-                Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/topic " + topicLine));
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/topic " + topicLine));
+                Assert.Equal("The room 'room' is closed.", ex.Message);
             }
 
             [Fact]
@@ -5480,7 +5555,7 @@ namespace JabbR.Test
                 string topicLine = new String('A', 81);
                 var exception = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/topic " + topicLine));
 
-                Assert.Equal("Sorry, but your topic is too long. Can please keep it under 80 characters.", exception.Message);    
+                Assert.Equal("Sorry, but your topic is too long. Please keep it under 80 characters.", exception.Message);    
             }
 
             [Fact]
@@ -5570,7 +5645,7 @@ namespace JabbR.Test
                                                         notificationService.Object);
 
                 InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/broadcast"));
-                Assert.Equal("What did you want to broadcast?", ex.Message);
+                Assert.Equal("What message do you want to broadcast?", ex.Message);
             }
 
             [Fact]
@@ -5632,7 +5707,7 @@ namespace JabbR.Test
                 string welcomeMessage = "This is the room's welcome message";
                 var exception = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/welcome " + welcomeMessage));
 
-                Assert.Equal("You are not an owner of room 'room'", exception.Message);
+                Assert.Equal("You are not an owner of room 'room'.", exception.Message);
             }
 
             [Fact]
@@ -5665,7 +5740,7 @@ namespace JabbR.Test
                 string welcomeMessage = "This is the room's welcome message";
                 var exception = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/welcome " + welcomeMessage));
 
-                Assert.Equal("The room 'room' is closed", exception.Message);
+                Assert.Equal("The room 'room' is closed.", exception.Message);
             }
 
             [Fact]
@@ -5729,7 +5804,7 @@ namespace JabbR.Test
                 string welcomeMessage = new String('A', 201);
                 var exception = Assert.Throws<InvalidOperationException>(() => commandManager.TryHandleCommand("/welcome " + welcomeMessage));
 
-                Assert.Equal("Sorry, but your welcome is too long. Can please keep it under 200 characters.", exception.Message);
+                Assert.Equal("Sorry, but your welcome is too long. Please keep it under 200 characters.", exception.Message);
             }
 
             [Fact]
@@ -5767,7 +5842,7 @@ namespace JabbR.Test
             }
         }
 
-        public static void VerifyThrows<T>(string command) where T : Exception
+        public static T VerifyThrows<T>(string command) where T : Exception
         {
             var repository = new InMemoryRepository();
             var cache = new Mock<ICache>().Object;
@@ -5781,7 +5856,7 @@ namespace JabbR.Test
                                                     cache,
                                                     notificationService.Object);
 
-            Assert.Throws<T>(() => commandManager.TryHandleCommand(command));
+            return Assert.Throws<T>(() => commandManager.TryHandleCommand(command));
         }
     }
 }

--- a/JabbR/Commands/AddOwnerCommand.cs
+++ b/JabbR/Commands/AddOwnerCommand.cs
@@ -21,7 +21,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(roomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to add ownership to?");
             }
 
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);

--- a/JabbR/Commands/AllowCommand.cs
+++ b/JabbR/Commands/AllowCommand.cs
@@ -10,7 +10,7 @@ namespace JabbR.Commands
         {
             if (args.Length == 0)
             {
-                throw new InvalidOperationException("Who do you want to allow?");
+                throw new InvalidOperationException("Who do you want to grant access permissions to?");
             }
 
             string targetUserName = args[0];
@@ -21,7 +21,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(roomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to allow access to?");
             }
 
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName, mustBeOpen: false);

--- a/JabbR/Commands/AllowedCommand.cs
+++ b/JabbR/Commands/AllowedCommand.cs
@@ -12,7 +12,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(targetRoomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to list the allowed users of?");
             }
 
             ChatRoom room = context.Repository.VerifyRoom(targetRoomName, mustBeOpen: false);

--- a/JabbR/Commands/BanCommand.cs
+++ b/JabbR/Commands/BanCommand.cs
@@ -11,7 +11,7 @@ namespace JabbR.Commands
         {
             if (args.Length == 0)
             {
-                throw new InvalidOperationException("Who are you trying to ban?");
+                throw new InvalidOperationException("Who do you want to ban?");
             }
 
             string targetUserName = args[0];

--- a/JabbR/Commands/BroadcastCommand.cs
+++ b/JabbR/Commands/BroadcastCommand.cs
@@ -14,7 +14,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(messageText))
             {
-                throw new InvalidOperationException("What did you want to broadcast?");
+                throw new InvalidOperationException("What message do you want to broadcast?");
             }
 
             context.NotificationService.BroadcastMessage(callingUser, messageText);

--- a/JabbR/Commands/CreateCommand.cs
+++ b/JabbR/Commands/CreateCommand.cs
@@ -10,7 +10,7 @@ namespace JabbR.Commands
         {
             if (args.Length > 1)
             {
-                throw new InvalidOperationException("Room name cannot contain spaces.");
+                throw new InvalidOperationException("Room names cannot contain spaces.");
             }
 
             if (args.Length == 0)
@@ -28,7 +28,7 @@ namespace JabbR.Commands
 
             if (room != null)
             {
-                throw new InvalidOperationException(String.Format("The room '{0}' already exists{1}",
+                throw new InvalidOperationException(String.Format("The room '{0}' already exists{1}.",
                     roomName,
                     room.Closed ? " but it's closed" : String.Empty));
             }

--- a/JabbR/Commands/GravatarCommand.cs
+++ b/JabbR/Commands/GravatarCommand.cs
@@ -14,7 +14,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrWhiteSpace(email))
             {
-                throw new InvalidOperationException("Email was not specified!");
+                throw new InvalidOperationException("Which email address do you want to use for the Gravatar image?");
             }
 
             string hash = email.ToLowerInvariant().ToMD5();

--- a/JabbR/Commands/InviteCodeCommand.cs
+++ b/JabbR/Commands/InviteCodeCommand.cs
@@ -18,7 +18,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(targetRoomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to show the invite code for?");
             }
 
             ChatRoom targetRoom = context.Repository.VerifyRoom(targetRoomName, mustBeOpen: false);

--- a/JabbR/Commands/InviteCommand.cs
+++ b/JabbR/Commands/InviteCommand.cs
@@ -26,7 +26,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(roomName))
             {
-                throw new InvalidOperationException("Invite them to which room?");
+                throw new InvalidOperationException("Which room do you want to invite them to?");
             }
 
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName, mustBeOpen: false);

--- a/JabbR/Commands/JoinCommand.cs
+++ b/JabbR/Commands/JoinCommand.cs
@@ -10,7 +10,7 @@ namespace JabbR.Commands
         {
             if (args.Length == 0)
             {
-                throw new InvalidOperationException("Join which room?");
+                throw new InvalidOperationException("Which room do you want to join?");
             }
 
             // Extract arguments

--- a/JabbR/Commands/KickCommand.cs
+++ b/JabbR/Commands/KickCommand.cs
@@ -10,7 +10,7 @@ namespace JabbR.Commands
         {
             if (args.Length == 0)
             {
-                throw new InvalidOperationException("Who are you trying to kick?");
+                throw new InvalidOperationException("Who do you want to to kick?");
             }
 
             string targetUserName = args[0];
@@ -21,7 +21,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(targetRoomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to kick them from?");
             }
 
             ChatRoom room = context.Repository.VerifyRoom(targetRoomName);

--- a/JabbR/Commands/LeaveCommand.cs
+++ b/JabbR/Commands/LeaveCommand.cs
@@ -12,7 +12,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(targetRoomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to leave?");
             }
 
             ChatRoom room = context.Repository.VerifyRoom(targetRoomName, mustBeOpen: false);

--- a/JabbR/Commands/ListCommand.cs
+++ b/JabbR/Commands/ListCommand.cs
@@ -13,7 +13,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(roomName))
             {
-                throw new InvalidOperationException("List users in which room?");
+                throw new InvalidOperationException("Which room do you want to list the current users of?");
             }
 
             ChatRoom room = context.Repository.VerifyRoom(roomName);

--- a/JabbR/Commands/NudgeCommand.cs
+++ b/JabbR/Commands/NudgeCommand.cs
@@ -35,7 +35,7 @@ namespace JabbR.Commands
             }
             else
             {
-                throw new InvalidOperationException(String.Format("Room can only be nudged once every {0} seconds", betweenNudges.TotalSeconds));
+                throw new InvalidOperationException(String.Format("Room can only be nudged once every {0} seconds.", betweenNudges.TotalSeconds));
             }
         }
 
@@ -60,7 +60,7 @@ namespace JabbR.Commands
             var betweenNudges = TimeSpan.FromSeconds(60);
             if (toUser.LastNudged.HasValue && toUser.LastNudged > DateTime.Now.Subtract(betweenNudges))
             {
-                throw new InvalidOperationException(String.Format("User can only be nudged once every {0} seconds", betweenNudges.TotalSeconds));
+                throw new InvalidOperationException(String.Format("User can only be nudged once every {0} seconds.", betweenNudges.TotalSeconds));
             }
 
             toUser.LastNudged = DateTime.Now;

--- a/JabbR/Commands/PrivateMessageCommand.cs
+++ b/JabbR/Commands/PrivateMessageCommand.cs
@@ -18,7 +18,7 @@ namespace JabbR.Commands
 
             if (args.Length == 0 || String.IsNullOrWhiteSpace(args[0]))
             {
-                throw new InvalidOperationException("Who are you trying send a private message to?");
+                throw new InvalidOperationException("Who do you want to send a private message to?");
             }
             var toUserName = args[0];
             ChatUser toUser = context.Repository.VerifyUser(toUserName);
@@ -32,7 +32,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(messageText))
             {
-                throw new InvalidOperationException(String.Format("What did you want to say to '{0}'?", toUser.Name));
+                throw new InvalidOperationException(String.Format("What do you want to say to '{0}'?", toUser.Name));
             }
 
             context.NotificationService.SendPrivateMessage(callingUser, toUser, messageText);

--- a/JabbR/Commands/RemoveOwnerCommand.cs
+++ b/JabbR/Commands/RemoveOwnerCommand.cs
@@ -21,7 +21,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(roomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to remove the owner from?");
             }
 
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);

--- a/JabbR/Commands/ResetInviteCodeCommand.cs
+++ b/JabbR/Commands/ResetInviteCodeCommand.cs
@@ -18,7 +18,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(targetRoomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to reset the invite code of?");
             }
 
             ChatRoom targetRoom = context.Repository.VerifyRoom(targetRoomName, mustBeOpen: false);

--- a/JabbR/Commands/UnAllowCommand.cs
+++ b/JabbR/Commands/UnAllowCommand.cs
@@ -10,7 +10,7 @@ namespace JabbR.Commands
         {
             if (args.Length == 0)
             {
-                throw new InvalidOperationException("Which user to you want to revoke permissions from?");
+                throw new InvalidOperationException("Who you want to revoke access permissions from?");
             }
 
             string targetUserName = args[0];
@@ -21,7 +21,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(roomName))
             {
-                throw new InvalidOperationException("Which room do you want to the user's access permissions from?");
+                throw new InvalidOperationException("Which room do you want to revoke access from?");
             }
 
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName, mustBeOpen: false);

--- a/JabbR/Commands/UnAllowCommand.cs
+++ b/JabbR/Commands/UnAllowCommand.cs
@@ -10,7 +10,7 @@ namespace JabbR.Commands
         {
             if (args.Length == 0)
             {
-                throw new InvalidOperationException("Which user to you want to revoke persmissions from?");
+                throw new InvalidOperationException("Which user to you want to revoke permissions from?");
             }
 
             string targetUserName = args[0];
@@ -21,7 +21,7 @@ namespace JabbR.Commands
 
             if (String.IsNullOrEmpty(roomName))
             {
-                throw new InvalidOperationException("Which room?");
+                throw new InvalidOperationException("Which room do you want to the user's access permissions from?");
             }
 
             ChatRoom targetRoom = context.Repository.VerifyRoom(roomName, mustBeOpen: false);

--- a/JabbR/Commands/WhereCommand.cs
+++ b/JabbR/Commands/WhereCommand.cs
@@ -10,7 +10,7 @@ namespace JabbR.Commands
         {
             if (args.Length == 0)
             {
-                throw new InvalidOperationException("Who are you trying to locate?");
+                throw new InvalidOperationException("Who do you want to locate?");
             }
 
             string targetUserName = args[0];

--- a/JabbR/Commands/WhoCommand.cs
+++ b/JabbR/Commands/WhoCommand.cs
@@ -21,7 +21,7 @@ namespace JabbR.Commands
 
             if (user == null)
             {
-                throw new InvalidOperationException(String.Format("We didn't find anyone with the username {0}", name));
+                throw new InvalidOperationException(String.Format("We didn't find anyone with the username {0}.", name));
             }
 
             context.NotificationService.ShowUserInfo(user);

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -434,7 +434,7 @@ namespace JabbR
                 !room.Owners.Contains(user) ||
                 (room.Private && !user.AllowedRooms.Contains(room)))
             {
-                throw new InvalidOperationException("You're not allowed to post a notification");
+                throw new InvalidOperationException("You're not allowed to post a notification.");
             }
 
             var chatMessage = new ChatMessage

--- a/JabbR/Models/ModelExtensions.cs
+++ b/JabbR/Models/ModelExtensions.cs
@@ -9,7 +9,7 @@ namespace JabbR.Models
         {
             if (room.Private && !room.IsUserAllowed(user))
             {
-                throw new InvalidOperationException("You do not have access to " + room.Name);
+                throw new InvalidOperationException(String.Format("You do not have access to {0}.", room.Name));
             }
         }
 
@@ -22,7 +22,7 @@ namespace JabbR.Models
         {
             if (room.Closed)
             {
-                throw new InvalidOperationException(string.Format("The room '{0}' is closed", room.Name));
+                throw new InvalidOperationException(String.Format("The room '{0}' is closed.", room.Name));
             }
         }
     }

--- a/JabbR/Models/RepositoryExtensions.cs
+++ b/JabbR/Models/RepositoryExtensions.cs
@@ -103,12 +103,12 @@ namespace JabbR.Models
 
             if (room == null)
             {
-                throw new InvalidOperationException(String.Format("Unable to find room '{0}'", roomName));
+                throw new InvalidOperationException(String.Format("Unable to find room '{0}'.", roomName));
             }
 
             if (room.Closed && mustBeOpen)
             {
-                throw new InvalidOperationException(String.Format("The room '{0}' is closed", roomName));
+                throw new InvalidOperationException(String.Format("The room '{0}' is closed.", roomName));
             }
 
             return room;

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -350,7 +350,7 @@ namespace JabbR.Services
             EnsureOwnerOrAdmin(user, room);
             if (!room.Private)
             {
-                throw new InvalidOperationException("Only private rooms can have invite codes");
+                throw new InvalidOperationException("Only private rooms can have invite codes.");
             }
 
             // Set the invite code and save
@@ -604,7 +604,7 @@ namespace JabbR.Services
         {
             if (!user.IsAdmin)
             {
-                throw new InvalidOperationException("You are not an admin");
+                throw new InvalidOperationException("You are not an admin.");
             }
         }
 
@@ -612,7 +612,7 @@ namespace JabbR.Services
         {
             if (!room.Owners.Contains(user) && !user.IsAdmin)
             {
-                throw new InvalidOperationException("You are not an owner of room '" + room.Name + "'");
+                throw new InvalidOperationException(String.Format("You are not an owner of room '{0}'.", room.Name));
             }
         }
 
@@ -620,7 +620,7 @@ namespace JabbR.Services
         {
             if (!room.Owners.Contains(user))
             {
-                throw new InvalidOperationException("You are not an owner of room '" + room.Name + "'");
+                throw new InvalidOperationException(String.Format("You are not an owner of room '{0}'.", room.Name));
             }
         }
 
@@ -628,7 +628,7 @@ namespace JabbR.Services
         {
             if (user != room.Creator)
             {
-                throw new InvalidOperationException("You are not the creator of " + room.Name);
+                throw new InvalidOperationException(String.Format("You are not the creator of room '{0}'", room.Name));
             }
         }
 
@@ -636,7 +636,7 @@ namespace JabbR.Services
         {
             if (user != room.Creator && !user.IsAdmin)
             {
-                throw new InvalidOperationException("You are not the creator of room '" + room.Name + "'");
+                throw new InvalidOperationException(String.Format("You are not the creator of room '{0}'.", room.Name));
             }
         }
 
@@ -809,7 +809,7 @@ namespace JabbR.Services
 
             if (targetUser.IsAdmin)
             {
-                throw new InvalidOperationException("You cannot ban another Admin.");
+                throw new InvalidOperationException("You cannot ban another admin.");
             }
 
             targetUser.IsBanned = true;
@@ -824,7 +824,7 @@ namespace JabbR.Services
                 note.Length > lengthToValidateFor)
             {
                 throw new InvalidOperationException(
-                    String.Format("Sorry, but your {1} is too long. Can please keep it under {0} characters.",
+                    String.Format("Sorry, but your {1} is too long. Please keep it under {0} characters.",
                         lengthToValidateFor, noteTypeName));
             }
         }


### PR DESCRIPTION
Currently, the wording, length and punctuation on InvalidOperationExceptions (which are shown to the user when something fails in a command) are inconsistent.

This change changes the messages to, where appropriate, use phrasing like:

"Who do you want to (perform action phrase here)?"
"Which room do you want to (perform action phrase here)?"

and ensures punctuation at the end of each message.  I've also extended the tests to verify the messages that are returned so that we're more aware if regressions occur.
