### PR TITLE
Update Travis-CI build badge after Org move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## JabbR [![Build Status](https://travis-ci.org/davidfowl/JabbR.png)](https://travis-ci.org/davidfowl/JabbR)
+## JabbR [![Build Status](https://travis-ci.org/JabbR/JabbR.png)](https://travis-ci.org/JabbR/JabbR)
 JabbR is a chat application built with ASP.NET using SignalR. 
 
 ![jabbr.net](https://jabbr.blob.core.windows.net/jabbr-uploads/Screen%20Shot%202013-04-01%20at%207.57.53%20PM_d6a3.png)


### PR DESCRIPTION
You will need to setup the GitHub hook again http://about.travis-ci.org/docs/user/getting-started/ now that the project moved to a new organization/owner.
