### PR TITLE
switch pulse target to chat-area because IE (10) doesn't pulse the body on nudges

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -653,7 +653,7 @@
             }
         }
 
-        $("body").pulse({ opacity: 0 }, { duration: 300, pulses: 3 });
+        $("#chat-area").pulse({ opacity: 0 }, { duration: 300, pulses: 3 });
 
         window.setTimeout(function () {
             shake(20);


### PR DESCRIPTION
Other browsers seem to work fine, but IE doesn't pulse anything when the effect is applied to document.body.
