### PR TITLE
DefaultAuthenticationProvider in JabbR.Client does not set Uri path correctly.

### DIFF
--- a/JabbR.Client/DefaultAuthenticationProvider.cs
+++ b/JabbR.Client/DefaultAuthenticationProvider.cs
@@ -22,10 +22,8 @@ namespace JabbR.Client
             var content = String.Format("username={0}&password={1}", Uri.EscapeUriString(userName), Uri.EscapeUriString(password));
             var contentBytes = Encoding.ASCII.GetBytes(content);
 
-            var authUri = new UriBuilder(_url)
-            {
-                Path = "account/login"
-            };
+            var authUri = new UriBuilder(_url);
+            authUri.Path += authUri.Path.EndsWith("/") ? "account/login" : "/account/login";
 
             var cookieJar = new CookieContainer();
             var request = (HttpWebRequest)WebRequest.Create(authUri.Uri);


### PR DESCRIPTION
It currently overrides the Path, so if JabbR is running in a virtual directory the virtual directory (path) is removed causing authentication to fail. Instead append the path to any existing path.
