### PR TITLE
Global status indicator as blocky rectangle, user status indicators as blocky rectangles next to messages

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -183,7 +183,9 @@
             isMine: message.User.Name === chat.state.name,
             imageUrl: message.ImageUrl,
             source: message.Source,
-            messageType: message.MessageType
+            messageType: message.MessageType,
+            presence: (message.UserRoomPresence || 'absent').toLowerCase(),
+            status: (message.User.Status || 'offline').toLowerCase()
         };
     }
 

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1579,7 +1579,8 @@
         },
         addUser: function (userViewModel, roomName) {
             var room = getRoomElements(roomName),
-                $user = null;
+                $user = null,
+                $userMessages = room.messages.find(getUserClassName(userViewModel.name));
 
             // Remove all users that are being removed
             room.users.find('.removing').remove();
@@ -1596,6 +1597,8 @@
             $user.data('owner', userViewModel.owner);
             $user.data('admin', userViewModel.admin);
 
+            $userMessages.find('.user').removeClass('offline active inactive absent present').addClass('active present');
+
             room.addUser(userViewModel, $user);
             updateNote(userViewModel, $user);
             updateFlag(userViewModel, $user);
@@ -1604,46 +1607,60 @@
         },
         setUserActivity: function (userViewModel) {
             var $user = $('.users').find(getUserClassName(userViewModel.name)),
-                active = $user.data('active'),
-                $idleSince = $user.find('.idle-since');
+                $inactiveSince = $user.find('.inactive-since'),
+                $userMessages = $('.messages').find(getUserClassName(userViewModel.name));
 
             if (userViewModel.active === true) {
-                if ($user.hasClass('idle')) {
-                    $user.removeClass('idle');
-                    $idleSince.livestamp('destroy');
+                if ($user.hasClass('inactive')) {
+                    $user.removeClass('inactive');
+                    $inactiveSince.livestamp('destroy');
                 }
+                
+                $userMessages.find('.user').removeClass('offline active inactive').addClass('active');
             } else {
-                if (!$user.hasClass('idle')) {
-                    $user.addClass('idle');
+                if (!$user.hasClass('inactive')) {
+                    $user.addClass('inactive');
                 }
 
-                if (!$idleSince.html()) {
-                    $idleSince.livestamp(userViewModel.lastActive);
+                if (!$inactiveSince.html()) {
+                    $inactiveSince.livestamp(userViewModel.lastActive);
                 }
+                
+                $userMessages.find('.user').removeClass('offline active inactive').addClass('inactive');
             }
 
             updateNote(userViewModel, $user);
         },
         setUserActive: function ($user) {
-            var $idleSince = $user.find('.idle-since');
+            var $inactiveSince = $user.find('.inactive-since'),
+                $userMessages = $('.messages').find(getUserClassName($user.data('name')));
+            
             if ($user.data('active') === true) {
                 return false;
             }
             $user.attr('data-active', true);
             $user.data('active', true);
-            $user.removeClass('idle');
-            if ($idleSince.livestamp('isLiveStamp')) {
-                $idleSince.livestamp('destroy');
+            $user.removeClass('inactive');
+            if ($inactiveSince.livestamp('isLiveStamp')) {
+                $inactiveSince.livestamp('destroy');
             }
+            
+            $userMessages.find('.user').removeClass('offline active inactive').addClass('active');
+
             return true;
         },
         setUserInActive: function ($user) {
+            var $userMessages = $('.messages').find(getUserClassName($user.data('name')));
+            
             if ($user.data('active') === false) {
                 return false;
             }
             $user.attr('data-active', false);
             $user.data('active', false);
-            $user.addClass('idle');
+            $user.addClass('inactive');
+            
+            $userMessages.find('.user').removeClass('offline active inactive').addClass('inactive');
+            
             return true;
         },
         changeUserName: function (oldName, user, roomName) {
@@ -1679,7 +1696,8 @@
         },
         removeUser: function (user, roomName) {
             var room = getRoomElements(roomName),
-                $user = room.getUser(user.Name);
+                $user = room.getUser(user.Name),
+                $userMessages = room.messages.find(getUserClassName(user.Name));
 
             $user.addClass('removing')
                 .fadeOut('slow', function () {
@@ -1692,6 +1710,8 @@
                         room.setListState(room.activeUsers);
                     }
                 });
+            
+            $userMessages.find('.user').removeClass('absent present').addClass('absent');
         },
         setUserTyping: function (userViewModel, roomName) {
             var room = getRoomElements(roomName),

--- a/JabbR/Chat.ui.room.js
+++ b/JabbR/Chat.ui.room.js
@@ -251,18 +251,18 @@
         if (userViewModel.owner) {
             this.addUserToList($user, this.owners);
         } else {
-            this.changeIdle($user, userViewModel.active);
+            this.changeInactive($user, userViewModel.active);
 
             this.addUserToList($user, this.activeUsers);
 
         }
     };
 
-    Room.prototype.changeIdle = function ($user, isActive) {
+    Room.prototype.changeInactive = function ($user, isActive) {
         if (isActive) {
-            $user.removeClass('idle');
+            $user.removeClass('inactive');
         } else {
-            $user.addClass('idle');
+            $user.addClass('inactive');
         }
     };
 
@@ -296,7 +296,7 @@
         }
 
         if (!this.appearsInList($user, this.activeUsers)) {
-            this.changeIdle($user, status);
+            this.changeInactive($user, status);
 
             this.addUserToList($user, this.activeUsers);
         }

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -217,7 +217,7 @@ form#send-message {
             width: 16px;
             display: inline-block;
             float: left;
-            margin: 0 2px;
+            margin: 0 2px 0 0;
         }
 
 .message img {
@@ -543,8 +543,13 @@ li.user.typing .user-status {
     padding-right: 5px;
 }
 
-.users .idle .user-status {
+.inactive .user-status {
     background-color: #ffaa22;
+}
+
+.offline .user-status,
+.absent .user-status {
+    background-color: #fe1a00;
 }
 
 .users .details {
@@ -2712,7 +2717,7 @@ h3.userlist-header {
 }
 
 .reconnecting .icon-connection-status {
-    background-color: #ffec64;
+    background-color: #ffaa22;
 }
 
 .disconnected .icon-connection-status {
@@ -2750,7 +2755,7 @@ h3.userlist-header {
     color: white;
 }
 
-.idle-since {
+.inactive-since {
     float: right;
     font-size: 11px;
     font-weight: bold;
@@ -2862,7 +2867,7 @@ h3.userlist-header {
         width: 200px;
     }
 
-    .user.idle .details.admin .name-container .name {
+    .user.inactive .details.admin .name-container .name {
         width: 72px;
     }
 
@@ -2977,7 +2982,7 @@ h3.userlist-header {
         width: 45px;
     }
 
-    .user .details .name-container .idle-since {
+    .user .details .name-container .inactive-since {
         float: left;
     }
 

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -2701,16 +2701,14 @@ h3.userlist-header {
 .connection-status {
     float: left;
     position: relative;
-    top: 20px;
+    margin-top: 9px;
 }
 
 .icon-connection-status {
     background-color: #77d42a;
-    -webkit-border-radius: 8px;
-    -moz-border-radius: 8px;
-    border-radius: 8px;
-    display: inline-block;
-    padding: 6px;
+    display: block;
+    width: 10px;
+    height: 36px;
 }
 
 .reconnecting .icon-connection-status {
@@ -2780,7 +2778,7 @@ h3.userlist-header {
     box-shadow: none;
     border: 1px solid #e5e5e5;
     border-radius: 4px 4px 0 0;
-    margin: 9px 5px 0 5px;
+    margin: 9px 5px 0 0;
 }
 
 .navbar .nav {

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -880,5 +880,10 @@ namespace JabbR.Services
 
             return country;
         }
+
+        internal static string GetUserRoomPresence(ChatUser user, ChatRoom room)
+        {
+            return user.Rooms.Contains(room) ? "present" : "absent";
+        }
     }
 }

--- a/JabbR/ViewModels/MessageViewModel.cs
+++ b/JabbR/ViewModels/MessageViewModel.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using JabbR.Models;
+using JabbR.Services;
 
 namespace JabbR.ViewModels
 {
-    using JabbR.Services;
-
     public class MessageViewModel
     {
         public MessageViewModel(ChatMessage message)

--- a/JabbR/ViewModels/MessageViewModel.cs
+++ b/JabbR/ViewModels/MessageViewModel.cs
@@ -3,6 +3,8 @@ using JabbR.Models;
 
 namespace JabbR.ViewModels
 {
+    using JabbR.Services;
+
     public class MessageViewModel
     {
         public MessageViewModel(ChatMessage message)
@@ -11,6 +13,7 @@ namespace JabbR.ViewModels
             Content = message.Content;
             HtmlContent = message.HtmlContent;
             User = new UserViewModel(message.User);
+            UserRoomPresence = ChatService.GetUserRoomPresence(message.User, message.Room);
             When = message.When;
             HtmlEncoded = message.HtmlEncoded;
             MessageType = message.MessageType;
@@ -25,6 +28,7 @@ namespace JabbR.ViewModels
         public DateTimeOffset When { get; set; }
         public UserViewModel User { get; set; }
         public int MessageType { get; set; }
+        public string UserRoomPresence { get; set; }
 
         public string ImageUrl { get; set; }
         public string Source { get; set; }

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -46,8 +46,13 @@
         <li class="message ${highlight} clearfix{{if isMine}} my-message{{/if}}{{if showUser}} first{{/if}}" id="m-${id}" data-name="${name}" data-timestamp="${date}">
             <div class="left">
                 {{if showUser}}
-                <img src="https://secure.gravatar.com/avatar/${hash}?s=16&d=mm" class="gravatar" />
-                <div class="name">${name}</div>
+                <div class="user ${status} ${presence}">
+                    <div class="user-status-container">
+                        <i class="user-status"></i>
+                    </div>
+                    <img src="https://secure.gravatar.com/avatar/${hash}?s=16&d=mm" class="gravatar" />
+                    <div class="name">${name}</div>
+                </div>
                 {{/if}}
                 <span class="state"></span>
             </div>
@@ -117,7 +122,7 @@
                 </div>
                 <div class="name-container">
                     <div class="name" {{if note}}title="${note}"{{else}}title="${name}"{{/if}}>${name}</div>
-                    <div class="idle-since"></div>
+                    <div class="inactive-since"></div>
                     {{if admin}}<div class="admin">(admin)</div>{{/if}}
                 </div>
                 <div style="clear:both"></div>


### PR DESCRIPTION
Also renames idle throughout UI to inactive (to match underlying user status).

![jabbr-status-updates](https://f.cloud.github.com/assets/1271535/751976/ceef0970-e526-11e2-844d-cdd950fd6826.png)
