### PR TITLE
Notification support for firefox 22+

### DIFF
--- a/JabbR/Chat.toast.js
+++ b/JabbR/Chat.toast.js
@@ -1,95 +1,151 @@
 ﻿/// <reference path="Scripts/jquery-1.7.js" />
-(function($, window, utility) {
+(function ($, window, utility) {
     "use strict";
 
-    var ToastStatus = { Allowed: 0, NotConfigured: 1, Blocked: 2 },
-        toastTimeOut = 10000,
-        chromeToast = null,
-        toastRoom = null;
-
     var toast = {
+        current: null,
+        timeOut: 10000,
+
+        //default all permission checks to not allowed
+        isAllowed: function () { return false },
+        isNotConfigured: function () { return false },
+        isBlocked: function () { return true; },
+
         canToast: function () {
-            // we can toast if webkitNotifications exist and the user hasn't explicitly denied
-            return window.webkitNotifications && window.webkitNotifications.checkPermission() !== ToastStatus.Blocked;
+            return !this.isBlocked();
         },
         ensureToast: function (preferences) {
-            if (window.webkitNotifications &&
-                window.webkitNotifications.checkPermission() === ToastStatus.NotConfigured) {
+            if (this.isNotConfigured()) {
                 preferences.canToast = false;
             }
         },
-        toastMessage: function(message, roomName) {
-            if (!window.webkitNotifications ||
-                window.webkitNotifications.checkPermission() !== ToastStatus.Allowed) {
+        onToastShow: function () {
+            setTimeout(function () {
+                toast.hideToast();
+            }, toast.timeOut);
+        },
+        onToastClick: function () {
+            var room = toast.current.roomName;
+            toast.hideToast();
+            // Trigger the focus events - focus the window and open the source room
+            window.focus();
+            $(toast).trigger('toast.focus', [room]);
+        },
+        toastMessage: function (msg, roomName) {
+            if (!this.isAllowed()) {
                 return;
             }
+            this.hideToast();
 
-            var toastTitle = utility.trim(message.name, 21);
-            // we can reliably show 22 chars
-            if (toastTitle.length <= 19) {
-                toastTitle += ' (' + utility.trim(roomName, 19 - toastTitle.length) + ')';
-            }
-
-            toastRoom = roomName;
-
-            // Hide any previously displayed toast
-            toast.hideToast();
-
-            chromeToast = window.webkitNotifications.createNotification(
-                'Content/images/logo32.png',
-                toastTitle,
-                $('<div/>').html(message.message).text());
-
-            chromeToast.ondisplay = function () {
-                setTimeout(function () {
-                    chromeToast.cancel();
-                }, toastTimeOut);
-            };
-
-            chromeToast.onclick = function () {
-                toast.hideToast();
-                                
-                // Trigger the focus events - focus the window and open the source room
-                $(toast).trigger('toast.focus', [toastRoom]);
-            };
-
-            chromeToast.show();
+            this.current = this.createNotification(msg, roomName);
+            //little dirty, but it makes triggering focus later easier, without using a static variable
+            this.current.roomName = roomName;
         },
-        hideToast: function() {
-            if (chromeToast && chromeToast.cancel) {
-                chromeToast.cancel();
+        hideToast: function () {
+            if (this.current) {
+                this.removeNotification(this.current);
+                this.current = null;
             }
         },
-        enableToast: function(callback) {
+        enableToast: function (callback) {
             var deferred = $.Deferred();
-            if (window.webkitNotifications) {
-                // If not configured, request permission
-                if (window.webkitNotifications.checkPermission() === ToastStatus.NotConfigured) {
-                    window.webkitNotifications.requestPermission(function () {
-                        if (window.webkitNotifications.checkPermission()) {
-                            deferred.reject();
-                        }
-                        else {
-                            deferred.resolve();
-                        }
-                    });
-                }
-                else if (window.webkitNotifications.checkPermission() === ToastStatus.Allowed) {
-                    // If we're allowed then just resolve here
-                    deferred.resolve();
-                }
-                else {
-                    // We don't have permission
-                    deferred.reject();
-                }
+            // If not configured, request permission
+            if (this.isNotConfigured()) {
+                this.requestPermission(function () {
+                    if (!toast.isAllowed()) {
+                        deferred.reject();
+                    }
+                    else {
+                        deferred.resolve();
+                    }
+                });
+            }
+            else if (this.isAllowed()) {
+                // If we're allowed then just resolve here
+                deferred.resolve();
+            }
+            else {
+                // We don't have permission
+                deferred.reject();
             }
 
             return deferred;
         }
     };
-    
+
+
+    var html5Toast = function () {
+        return {
+            isAllowed: function () { return Notification.permission === 'granted' },
+            isNotConfigured: function () { return Notification.permission === 'default' },
+            isBlocked: function () { return Notification.permission === 'denied' },
+
+            createNotification: function (msg, roomName) {
+                //firefox doesnt set a limitation on notification title, but we will use an arbituary sane limit
+                var title = utility.trim(message.name, 50) + ' (' + roomName + ')';
+                var notification = new Notification(title, {
+                    lang: '',
+                    dir: 'auto',
+                    body: $('<div/>').html(msg.message).text(),
+                    tag: roomName,
+                    icon: 'Content/images/logo32.png'
+                });
+                notification.onshow = this.onToastShow;
+                notification.onclick = this.onToastClick;
+                return notification;
+            },
+            removeNotification: function (notification) {
+                notification.close();
+            },
+            requestPermission: function (callback) {
+                Notification.requestPermission(callback);
+            }
+        }
+    };
+
+    var webkitToast = function () {
+        return {
+            isAllowed: function () { return window.webkitNotifications.checkPermission() === 0 },
+            isNotConfigured: function () { return window.webkitNotifications.checkPermission() === 1 },
+            isBlocked: function () { return window.webkitNotifications.checkPermission() === 2 },
+
+            createNotification: function (message, roomName) {
+                var toastTitle = utility.trim(message.name, 21);
+                // we can reliably show 22 chars
+                if (toastTitle.length <= 19) {
+                    toastTitle += ' (' + utility.trim(roomName, 19 - toastTitle.length) + ')';
+                }
+
+                var notification = window.webkitNotifications.createNotification(
+                    'Content/images/logo32.png',
+                    toastTitle,
+                    $('<div/>').html(message.message).text());
+
+                notification.ondisplay = this.onToastShow;
+                notification.onclick = this.onToastClick;
+                notification.show();
+                return notification;
+            },
+            removeNotification: function (notification) {
+                notification.cancel();
+            },
+            requestPermission: function (callback) {
+                window.webkitNotifications.requestPermission(callback);
+            }
+        };
+    };
+
     if (!window.chat) {
         window.chat = {};
     }
+
+    //pick which browser implementation we want
+    if (window.webkitNotifications) {
+        toast = $.extend(toast, webkitToast());
+    } else if (typeof (Notification) !== 'undefined') {
+        toast = $.extend(toast, html5Toast());
+    }
+
     window.chat.toast = toast;
+
 })(jQuery, window, window.chat.utility);

--- a/JabbR/Chat.toast.js
+++ b/JabbR/Chat.toast.js
@@ -1,5 +1,5 @@
 /// <reference path="Scripts/jquery-1.7.js" />
-(function ($, window, utility) {
+(function($, window, utility) {
     "use strict";
 
     var toast = {
@@ -7,32 +7,32 @@
         timeOut: 10000,
 
         //default all permission checks to not allowed
-        isAllowed: function () { return false; },
-        isNotConfigured: function () { return false; },
-        isBlocked: function () { return true; },
+        isAllowed: function() { return false; },
+        isNotConfigured: function() { return false; },
+        isBlocked: function() { return true; },
 
-        canToast: function () {
+        canToast: function() {
             return !this.isBlocked();
         },
-        ensureToast: function (preferences) {
-            if (this.isNotConfigured()) {
+        ensureToast: function(preferences) {
+            if(this.isNotConfigured()) {
                 preferences.canToast = false;
             }
         },
-        onToastShow: function () {
-            setTimeout(function () {
+        onToastShow: function() {
+            setTimeout(function() {
                 toast.hideToast();
             }, toast.timeOut);
         },
-        onToastClick: function () {
+        onToastClick: function() {
             var room = toast.current.roomName;
             toast.hideToast();
             // Trigger the focus events - focus the window and open the source room
             window.focus();
             $(toast).trigger('toast.focus', [room]);
         },
-        toastMessage: function (msg, roomName) {
-            if (!this.isAllowed()) {
+        toastMessage: function(msg, roomName) {
+            if(!this.isAllowed()) {
                 return;
             }
             this.hideToast();
@@ -41,18 +41,18 @@
             //little dirty, but it makes triggering focus later easier, without using a static variable
             this.current.roomName = roomName;
         },
-        hideToast: function () {
-            if (this.current) {
+        hideToast: function() {
+            if(this.current) {
                 this.removeNotification(this.current);
                 this.current = null;
             }
         },
-        enableToast: function (callback) {
+        enableToast: function(callback) {
             var deferred = $.Deferred();
             // If not configured, request permission
-            if (this.isNotConfigured()) {
-                this.requestPermission(function () {
-                    if (!toast.isAllowed()) {
+            if(this.isNotConfigured()) {
+                this.requestPermission(function() {
+                    if(!toast.isAllowed()) {
                         deferred.reject();
                     }
                     else {
@@ -60,7 +60,7 @@
                     }
                 });
             }
-            else if (this.isAllowed()) {
+            else if(this.isAllowed()) {
                 // If we're allowed then just resolve here
                 deferred.resolve();
             }
@@ -76,11 +76,11 @@
 
     function html5Toast() {
         return $.extend(toast, {
-            isAllowed: function () { return window.Notification.permission === 'granted'; },
-            isNotConfigured: function () { return window.Notification.permission === 'default'; },
-            isBlocked: function () { return window.Notification.permission === 'denied'; },
+            isAllowed: function() { return window.Notification.permission === 'granted'; },
+            isNotConfigured: function() { return window.Notification.permission === 'default'; },
+            isBlocked: function() { return window.Notification.permission === 'denied'; },
 
-            createNotification: function (msg, roomName) {
+            createNotification: function(msg, roomName) {
                 //firefox doesnt set a limitation on notification title, but we will use an arbituary sane limit
                 var title = utility.trim(msg.name, 50) + ' (' + roomName + ')';
                 var notification = new window.Notification(title, {
@@ -93,10 +93,10 @@
                 notification.onclick = this.onToastClick;
                 return notification;
             },
-            removeNotification: function (notification) {
+            removeNotification: function(notification) {
                 notification.close();
             },
-            requestPermission: function (callback) {
+            requestPermission: function(callback) {
                 window.Notification.requestPermission(callback);
             }
         });
@@ -104,14 +104,14 @@
 
     function webkitToast() {
         return $.extend(toast, {
-            isAllowed: function () { return window.webkitNotifications.checkPermission() === 0; },
-            isNotConfigured: function () { return window.webkitNotifications.checkPermission() === 1; },
-            isBlocked: function () { return window.webkitNotifications.checkPermission() === 2; },
+            isAllowed: function() { return window.webkitNotifications.checkPermission() === 0; },
+            isNotConfigured: function() { return window.webkitNotifications.checkPermission() === 1; },
+            isBlocked: function() { return window.webkitNotifications.checkPermission() === 2; },
 
-            createNotification: function (message, roomName) {
+            createNotification: function(message, roomName) {
                 var toastTitle = utility.trim(message.name, 21);
                 // we can reliably show 22 chars
-                if (toastTitle.length <= 19) {
+                if(toastTitle.length <= 19) {
                     toastTitle += ' (' + utility.trim(roomName, 19 - toastTitle.length) + ')';
                 }
 
@@ -125,24 +125,24 @@
                 notification.show();
                 return notification;
             },
-            removeNotification: function (notification) {
+            removeNotification: function(notification) {
                 notification.cancel();
             },
-            requestPermission: function (callback) {
+            requestPermission: function(callback) {
                 window.webkitNotifications.requestPermission(callback);
             }
         });
     }
 
-    if (!window.chat) {
+    if(!window.chat) {
         window.chat = {};
     }
 
     //pick which implementation we want
     //chrome has the Notification object but not much else, so we need to check the permission property to be sure
-    if (typeof (window.Notification) && typeof (window.Notification.permission) === 'string') {
+    if(window.Notification && typeof window.Notification.permission === 'string') {
         toast = html5Toast();
-    } else if (window.webkitNotifications) {
+    } else if(window.webkitNotifications) {
         toast = webkitToast();
     }
 

--- a/JabbR/Chat.toast.js
+++ b/JabbR/Chat.toast.js
@@ -1,4 +1,4 @@
-﻿/// <reference path="Scripts/jquery-1.7.js" />
+/// <reference path="Scripts/jquery-1.7.js" />
 (function ($, window, utility) {
     "use strict";
 
@@ -7,8 +7,8 @@
         timeOut: 10000,
 
         //default all permission checks to not allowed
-        isAllowed: function () { return false },
-        isNotConfigured: function () { return false },
+        isAllowed: function () { return false; },
+        isNotConfigured: function () { return false; },
         isBlocked: function () { return true; },
 
         canToast: function () {
@@ -76,18 +76,17 @@
 
     function html5Toast() {
         return $.extend(toast, {
-            isAllowed: function () { return Notification.permission === 'granted' },
-            isNotConfigured: function () { return Notification.permission === 'default' },
-            isBlocked: function () { return Notification.permission === 'denied' },
+            isAllowed: function () { return window.Notification.permission === 'granted'; },
+            isNotConfigured: function () { return window.Notification.permission === 'default'; },
+            isBlocked: function () { return window.Notification.permission === 'denied'; },
 
             createNotification: function (msg, roomName) {
                 //firefox doesnt set a limitation on notification title, but we will use an arbituary sane limit
-                var title = utility.trim(message.name, 50) + ' (' + roomName + ')';
-                var notification = new Notification(title, {
+                var title = utility.trim(msg.name, 50) + ' (' + roomName + ')';
+                var notification = new window.Notification(title, {
                     lang: '',
                     dir: 'auto',
                     body: $('<div/>').html(msg.message).text(),
-                    tag: roomName,
                     icon: 'Content/images/logo32.png'
                 });
                 notification.onshow = this.onToastShow;
@@ -98,16 +97,16 @@
                 notification.close();
             },
             requestPermission: function (callback) {
-                Notification.requestPermission(callback);
+                window.Notification.requestPermission(callback);
             }
         });
-    };
+    }
 
     function webkitToast() {
         return $.extend(toast, {
-            isAllowed: function () { return window.webkitNotifications.checkPermission() === 0 },
-            isNotConfigured: function () { return window.webkitNotifications.checkPermission() === 1 },
-            isBlocked: function () { return window.webkitNotifications.checkPermission() === 2 },
+            isAllowed: function () { return window.webkitNotifications.checkPermission() === 0; },
+            isNotConfigured: function () { return window.webkitNotifications.checkPermission() === 1; },
+            isBlocked: function () { return window.webkitNotifications.checkPermission() === 2; },
 
             createNotification: function (message, roomName) {
                 var toastTitle = utility.trim(message.name, 21);
@@ -133,14 +132,15 @@
                 window.webkitNotifications.requestPermission(callback);
             }
         });
-    };
+    }
 
     if (!window.chat) {
         window.chat = {};
     }
 
     //pick which implementation we want
-    if (typeof (Notification) !== 'undefined') {
+    //chrome has the Notification object but not much else, so we need to check the permission property to be sure
+    if (typeof (window.Notification) && typeof (window.Notification.permission) === 'string') {
         toast = html5Toast();
     } else if (window.webkitNotifications) {
         toast = webkitToast();

--- a/JabbR/Chat.toast.js
+++ b/JabbR/Chat.toast.js
@@ -74,8 +74,8 @@
     };
 
 
-    var html5Toast = function () {
-        return {
+    function html5Toast() {
+        return $.extend(toast, {
             isAllowed: function () { return Notification.permission === 'granted' },
             isNotConfigured: function () { return Notification.permission === 'default' },
             isBlocked: function () { return Notification.permission === 'denied' },
@@ -100,11 +100,11 @@
             requestPermission: function (callback) {
                 Notification.requestPermission(callback);
             }
-        }
+        });
     };
 
-    var webkitToast = function () {
-        return {
+    function webkitToast() {
+        return $.extend(toast, {
             isAllowed: function () { return window.webkitNotifications.checkPermission() === 0 },
             isNotConfigured: function () { return window.webkitNotifications.checkPermission() === 1 },
             isBlocked: function () { return window.webkitNotifications.checkPermission() === 2 },
@@ -132,7 +132,7 @@
             requestPermission: function (callback) {
                 window.webkitNotifications.requestPermission(callback);
             }
-        };
+        });
     };
 
     if (!window.chat) {
@@ -141,9 +141,9 @@
 
     //pick which implementation we want
     if (typeof (Notification) !== 'undefined') {
-        toast = $.extend(toast, html5Toast());
+        toast = html5Toast();
     } else if (window.webkitNotifications) {
-        toast = $.extend(toast, webkitToast());
+        toast = webkitToast();
     }
 
     window.chat.toast = toast;

--- a/JabbR/Chat.toast.js
+++ b/JabbR/Chat.toast.js
@@ -139,11 +139,11 @@
         window.chat = {};
     }
 
-    //pick which browser implementation we want
-    if (window.webkitNotifications) {
-        toast = $.extend(toast, webkitToast());
-    } else if (typeof (Notification) !== 'undefined') {
+    //pick which implementation we want
+    if (typeof (Notification) !== 'undefined') {
         toast = $.extend(toast, html5Toast());
+    } else if (window.webkitNotifications) {
+        toast = $.extend(toast, webkitToast());
     }
 
     window.chat.toast = toast;


### PR DESCRIPTION
Redid most of the toast script so there can be (if needed) different implementations. At this stage there is 3:
- the default ( no toast)
- [Html 5 draft](http://www.w3.org/TR/notifications/) support. Although this support is cut down to function exactly like the existing toast, as opposed to the standard.
- Webkit support
