### PR TITLE
Less red in status for offline people

### DIFF
--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -550,7 +550,7 @@ li.user.typing .gravatar {
 
 .offline .user-status,
 .absent .user-status {
-    background-color: #fe1a00;
+    background-color: #e5e5e5;
 }
 
 .users .details {


### PR DESCRIPTION
Made the user offline / not present the same gray as the typing indicator.

![jabbr-offline-indicators](https://f.cloud.github.com/assets/1271535/759848/5cf5d024-e79c-11e2-87bc-68c1ee6668d0.png)
