### PR TITLE
Improve admin screen layout

### DIFF
--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -3056,10 +3056,7 @@ h3.userlist-header {
 {
     .form-horizontal .control-label
     {
-        float: none;
         width: auto;
-        padding-top: 0;
-        text-align: left;
     }
 
     .form-horizontal .controls

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -3039,27 +3039,27 @@ h3.userlist-header {
 }
 
 /* Make admin screens nicer */
-.form-horizontal .control-label {
+.administration .form-horizontal .control-label {
   width: 260px;
 }
 
-.form-horizontal .controls {
+.administration .form-horizontal .controls {
   margin-left: 280px;
   *margin-left: 0;
 }
 
-.form-horizontal .controls:first-child {
+.administration .form-horizontal .controls:first-child {
   *padding-left: 280px;
 }
 
 @media (max-width: 480px)
 {
-    .form-horizontal .control-label
+    .administration .form-horizontal .control-label
     {
         width: auto;
     }
 
-    .form-horizontal .controls
+    .administration .form-horizontal .controls
     {
         margin-left: 0;
     }

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -3037,3 +3037,33 @@ h3.userlist-header {
     border-collapse: collapse !important;
     background-image: none !important;
 }
+
+/* Make admin screens nicer */
+.form-horizontal .control-label {
+  width: 260px;
+}
+
+.form-horizontal .controls {
+  margin-left: 280px;
+  *margin-left: 0;
+}
+
+.form-horizontal .controls:first-child {
+  *padding-left: 280px;
+}
+
+@media (max-width: 480px)
+{
+    .form-horizontal .control-label
+    {
+        float: none;
+        width: auto;
+        padding-top: 0;
+        text-align: left;
+    }
+
+    .form-horizontal .controls
+    {
+        margin-left: 0;
+    }
+}

--- a/JabbR/Nancy/HtmlHelperExtensions.cs
+++ b/JabbR/Nancy/HtmlHelperExtensions.cs
@@ -19,7 +19,9 @@ namespace JabbR
             
             var checkBoxBuilder = new StringBuilder();
 
-            checkBoxBuilder.Append(@"<input data-name=""");
+            checkBoxBuilder.Append(@"<input id=""");
+            checkBoxBuilder.Append(AntiXSS.Encoder.HtmlAttributeEncode(Name));
+            checkBoxBuilder.Append(@""" data-name=""");
             checkBoxBuilder.Append(AntiXSS.Encoder.HtmlAttributeEncode(Name));
             checkBoxBuilder.Append(@""" type=""checkbox""");
             if (value)

--- a/JabbR/Views/Administration/index.cshtml
+++ b/JabbR/Views/Administration/index.cshtml
@@ -54,17 +54,17 @@
                     <div class="control-group">
                         <label class="control-label" for="requestResetPasswordValidThroughInHours">Reset Password Valid Through (Hours)</label>
                         <div class="controls">
-                            <input type="text" name="requestResetPasswordValidThroughInHours" class="input-mini" value="@Model.RequestResetPasswordValidThroughInHours" />
+                            <input type="text" id="requestResetPasswordValidThroughInHours" name="requestResetPasswordValidThroughInHours" class="input-mini" value="@Model.RequestResetPasswordValidThroughInHours" />
                         </div>
                     </div>
                     <div class="control-group">
-                        <label class="control-label" for="allowUserRegistration">Allow Room Creation</label>
+                        <label class="control-label" for="allowRoomCreation">Allow Room Creation</label>
                         <div class="controls">
                             @Html.CheckBox("allowRoomCreation", Model.AllowRoomCreation)
                         </div>
                     </div>
                 </fieldset>
-                <fieldset id="generalSettings">
+                <fieldset id="emailSettings">
                     <legend>Email Settings</legend>
                     <div class="control-group">
                         <label class="control-label" for="emailSender">Email Sender</label>
@@ -95,13 +95,13 @@
                     <div class="control-group">
                         <label class="control-label" for="azureBlobStorageConnectionString">Azure Blob Storage Connectionstring</label>
                         <div class="controls">
-                            <input type="text" name="azureBlobStorageConnectionString" class="input-xlarge" value="@Model.AzureblobStorageConnectionString" placeholder="Azure Blob Storage Connectionstring"/>
+                            <input type="text" id="azureBlobStorageConnectionString" name="azureBlobStorageConnectionString" class="input-xlarge" value="@Model.AzureblobStorageConnectionString" placeholder="Azure Blob Storage Connectionstring"/>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label" for="maxFileUploadBytes">Max File Upload Size (Bytes)</label>
                         <div class="controls">
-                            <input type="text" name="maxFileUploadBytes" class="input-xlarge" value="@Model.MaxFileUploadBytes" placeholder="Max File Upload Size (Bytes)"/>
+                            <input type="text" id="maxFileUploadBytes" name="maxFileUploadBytes" class="input-xlarge" value="@Model.MaxFileUploadBytes" placeholder="Max File Upload Size (Bytes)"/>
                         </div>
                     </div>
                 </fieldset>
@@ -110,7 +110,7 @@
                     <div class="control-group">
                         <label class="control-label" for="googleAnalytics">Google Analytics ID</label>
                         <div class="controls">
-                            <input type="text" name="googleAnalytics" class="input-xlarge" value="@Model.GoogleAnalytics" placeholder="Google Analytics ID"/>
+                            <input type="text" id="googleAnalytics" name="googleAnalytics" class="input-xlarge" value="@Model.GoogleAnalytics" placeholder="Google Analytics ID"/>
                         </div>
                     </div>
                 </fieldset>


### PR DESCRIPTION
Make the labels 100px wider than bootstrap's default, make the labels on the administration screen focus on the field on click.

![jabbr-increased-controlwidth](https://f.cloud.github.com/assets/1271535/779756/d4c26906-e9e9-11e2-8286-872d7dd1a03c.png)

Note that the increased width is present on the user management screens as well.

![jabbr-increased-controlwidth_6e72](https://f.cloud.github.com/assets/1271535/779760/02c3d790-e9ea-11e2-9ae1-c91475008ea5.png)
