### PR TITLE
Improve experience around imgur albums slightly

### DIFF
--- a/JabbR/ContentProviders/ImgurContentProvider.cs
+++ b/JabbR/ContentProviders/ImgurContentProvider.cs
@@ -13,14 +13,22 @@ namespace JabbR.ContentProviders
 
             return TaskAsyncHelper.FromResult(new ContentProviderResult()
             {
-                Content = String.Format(@"<img src=""proxy?url=http://i.imgur.com/{0}.jpg"" />", id),
+                Content = String.Format(@"<img src=""https://i.imgur.com/{0}.png"" />", id),
                 Title = request.RequestUri.AbsoluteUri
             });
         }
 
         public override bool IsValidContent(Uri uri)
         {
-            return uri.AbsoluteUri.StartsWith("http://imgur.com/", StringComparison.OrdinalIgnoreCase);
+            // not perfect, we have no way of differentiating eg http://imgur.com/random from a valid page
+            // we should also look at rewriting non-ssl images from imgur to https://i.imgur.com rather than proxying at some point.
+            bool isImgurDomain = uri.Host.Equals("imgur.com", StringComparison.OrdinalIgnoreCase) || 
+                uri.Host.Equals("www.imgur.com", StringComparison.OrdinalIgnoreCase) ||
+                uri.Host.Equals("i.imgur.com", StringComparison.OrdinalIgnoreCase);
+            return isImgurDomain &&
+                !uri.AbsolutePath.StartsWith("/a/", StringComparison.OrdinalIgnoreCase) &&
+                !uri.AbsolutePath.Equals("/", StringComparison.OrdinalIgnoreCase) &&
+                !uri.AbsolutePath.Contains(".");
         }
     }
 }


### PR DESCRIPTION
Made several small changes to address the direct issue in #954 - where if you have an /a/ link it tried to display but broke in the proxy.  Altered to avoid proxy, to allow for a wider range of pages, to skip already-image links.

Note that this doesn't entirely address the issues with imgur - we still don't know when a link is an image's page or an album's page if we are under /gallery/ (maybe need to bring in imgur API?), and there's no way to separate eg "/random" from valid images (other than building a big whitelist).
