### PR TITLE
Update client-sent messages with server time

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1817,6 +1817,7 @@
             processMessage(message);
 
             $message.find('.middle').html(message.message);
+            $message.find('.right .time').attr('title', message.fulldate).text(message.when);
             $message.attr('id', 'm-' + message.id);
 
         },


### PR DESCRIPTION
Should resolve issue #950

Caused by the client and server's time being out-of-sync, this PR updates the client's view of the message with the time recorded by the server.
