### PR TITLE
Fix tabheaders

### DIFF
--- a/JabbR/Chat.ui.room.js
+++ b/JabbR/Chat.ui.room.js
@@ -3,36 +3,6 @@
     
     var trimRoomHistoryMaxMessages = 200;
 
-    function glowTab($tab, n) {
-        // Stop if we're not unread anymore
-        if (!$tab.hasClass('unread')) {
-            return;
-        }
-
-        // Go light
-        $tab.animate({ backgroundColor: '#004B85', color: '#FFF' }, 800, function () {
-            // Stop if we're not unread anymore
-            if (!$tab.hasClass('unread')) {
-                return;
-            }
-
-            n--;
-
-            // Check if we're on our last glow
-            if (n !== 0) {
-                // Go dark
-                $tab.animate({ backgroundColor: '#003259', color: '#FFF' }, 800, function () {
-                    // Glow the tab again
-                    glowTab($tab, n);
-                });
-            }
-            else {
-                // Leave the tab highlighted
-                $tab.animate({ backgroundColor: '#004B85', color: '#FFF' }, 800);
-            }
-        });
-    }
-
     function getUserClassName(userName) {
         return '[data-name="' + userName + '"]';
     }
@@ -117,12 +87,6 @@
 
         $tab.data('unread', unread);
         $tab.data('hasMentions', hasMentions);
-
-        if (!this.isActive() && unread === 1) {
-            // If this room isn't active then we're going to glow the tab
-            // to get the user's attention
-            glowTab($tab, 6);
-        }
     };
 
     Room.prototype.scrollToBottom = function () {
@@ -196,7 +160,7 @@
                 .css('color', '')
                 .data('unread', 0)
                 .data('hasMentions', false);
-        
+
         if (this.tab.is('.room')) {
             this.tab.find('.content').text(this.getName());
         }

--- a/JabbR/Chat.ui.room.js
+++ b/JabbR/Chat.ui.room.js
@@ -155,9 +155,6 @@
 
         this.tab.addClass('current')
                 .removeClass('unread')
-                .stop(true, true)
-                .css('backgroundColor', '')
-                .css('color', '')
                 .data('unread', 0)
                 .data('hasMentions', false);
 

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -628,6 +628,7 @@ li.user.typing .gravatar {
         #tabs li a:hover,
         #tabs li.current a {
             text-decoration: none;
+            background-color: #e5e5e5;
         }
 
         #tabs li a i,
@@ -653,6 +654,21 @@ li.user.typing .gravatar {
 
         #tabs li.unread {
             background-color: #004b85;
+            animation: btn-fade-unread 2s linear 3.5;
+            -webkit-animation: btn-fade-unread 2s linear 3.5;
+        }
+
+        @-webkit-keyframes btn-fade-unread
+        {
+          0% { background-color: #003259; }
+          50% { background-color: #004b85; }
+          100% { background-color: #003259; }
+        }
+
+        @keyframes btn-fade-unread {
+          0% { background-color: #003259; }
+          50% { background-color: #004b85; }
+          100% { background-color: #003259; }
         }
 
         #tabs li.current,        

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -651,9 +651,13 @@ li.user.typing .gravatar {
             padding-right: 8px;
         }
 
+        #tabs li.unread {
+            background-color: #004b85;
+        }
+
         #tabs li.current,        
         #tabs li:hover {
-            background-color: #e5e5e5 !important; /* background is set on the element in js for inactive rooms */
+            background-color: #e5e5e5;
             border-color: #e5e5e5;
         }
 
@@ -698,11 +702,11 @@ li.user.typing .gravatar {
     #tabs-dropdown li {
         position: relative;
         cursor: pointer;
-        background-color: #fff !important;
+        background-color: #fff;
     }
 
     #tabs-dropdown li:hover {
-        background-color: #00103F !important;
+        background-color: #00103F;
     }
 
     #tabs-dropdown li:hover a,

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -153,8 +153,8 @@
                 <i class="icon-lock lock hide"></i>
                 <i class="icon-ban-circle readonly hide"></i>
                 <span class="content">${name}</span>
+                <button class="close">&times;</button>
             </a>
-            <button class="close">&times;</button>
         </li>
     </script>
     <script id="command-help-template" type="text/x-jquery-tmpl">


### PR DESCRIPTION
Remove animation on adding unread class to room header tabs, or fix #960.  I played around with CSS animations, but they don't seem powerful enough to handle what we want (fade-in but with interruption on hover) without adding extra dom elements.
