### PR TITLE
Fix private room user add message

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -457,7 +457,7 @@
     };
 
     chat.client.userAllowed = function (user, room) {
-        ui.addMessage(utility.getLanguageResource('Chat_YouGrantedRoomAccess', user, room), 'notification', this.state.activeRoom);
+        ui.addMessage(utility.getLanguageResource('Chat_UserGrantedRoomAccess', user, room), 'notification', this.state.activeRoom);
     };
 
     chat.client.unallowUser = function (user, room) {


### PR DESCRIPTION
We were using the wrong localised string for this message.  Now, the message is along the lines of "cjm1 now has access to MySupersekritRoom."
