### PR TITLE
Improve handling of room topic change (and associated minor refactoring)

### DIFF
--- a/JabbR.Client/ClientEvents.cs
+++ b/JabbR.Client/ClientEvents.cs
@@ -9,7 +9,7 @@
         public static readonly string LogOn = "logOn";
         public static readonly string LogOut = "logOut";
         public static readonly string Kick = "kick";
-        public static readonly string UpdateRoomCount = "updateRoomCount";
+        public static readonly string UpdateRoom = "updateRoom";
         public static readonly string UpdateActivity = "updateActivity";
         public static readonly string MarkInactive = "markInactive";
         public static readonly string SendPrivateMessage = "sendPrivateMessage";

--- a/JabbR.Client/IJabbRClient.cs
+++ b/JabbR.Client/IJabbRClient.cs
@@ -22,12 +22,12 @@ namespace JabbR.Client
         event Action<string, User, string> UsernameChanged;
         event Action<User, string> NoteChanged;
         event Action<User, string> FlagChanged;
-        event Action<Room> TopicChanged;
+        event Action<string, string, string> TopicChanged;
         event Action<User, string> OwnerAdded;
         event Action<User, string> OwnerRemoved;
         event Action<string, string, string> AddMessageContent;
         event Action<Room> JoinedRoom;
-        event Action<Room, int> RoomCountChanged;
+        event Action<Room> RoomChanged;
         event Action<User> UserActivityChanged;
         event Action<IEnumerable<User>> UsersInactive;
         event Action Disconnected;

--- a/JabbR.Client/JabbRClient.cs
+++ b/JabbR.Client/JabbRClient.cs
@@ -47,14 +47,14 @@ namespace JabbR.Client
         public event Action<string, User, string> UsernameChanged;
         public event Action<User, string> NoteChanged;
         public event Action<User, string> FlagChanged;
-        public event Action<Room> TopicChanged;
+        public event Action<string, string, string> TopicChanged;
         public event Action<User, string> OwnerAdded;
         public event Action<User, string> OwnerRemoved;
         public event Action<string, string, string> AddMessageContent;
         public event Action<Room> JoinedRoom;
 
         // Global
-        public event Action<Room, int> RoomCountChanged;
+        public event Action<Room> RoomChanged;
         public event Action<User> UserActivityChanged;
         public event Action<IEnumerable<User>> UsersInactive;
 
@@ -331,9 +331,9 @@ namespace JabbR.Client
                 Execute(Kicked, kicked => kicked(room));
             });
 
-            _chat.On<Room, int>(ClientEvents.UpdateRoomCount, (room, count) =>
+            _chat.On<Room>(ClientEvents.UpdateRoom, (room) =>
             {
-                Execute(RoomCountChanged, roomCountChanged => roomCountChanged(room, count));
+                Execute(RoomChanged, roomChanged => roomChanged(room));
             });
 
             _chat.On<User, string>(ClientEvents.UpdateActivity, (user, roomName) =>
@@ -381,9 +381,9 @@ namespace JabbR.Client
                 Execute(FlagChanged, flagChanged => flagChanged(user, room));
             });
 
-            _chat.On<Room>(ClientEvents.TopicChanged, (room) =>
+            _chat.On<string, string, string>(ClientEvents.TopicChanged, (roomName, topic, who) =>
             {
-                Execute(TopicChanged, topicChanged => topicChanged(room));
+                Execute(TopicChanged, topicChanged => topicChanged(roomName, topic, who));
             });
 
             _chat.On<User, string>(ClientEvents.OwnerAdded, (user, room) =>

--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -109,7 +109,7 @@
                         ui.addChatMessage(viewModel, room);
                     });
 
-                    ui.changeRoomTopic(roomInfo);
+                    ui.changeRoomTopic(roomInfo.Name, roomInfo.Topic);
 
                     // mark room as initialized to differentiate messages
                     // that are added after initial population
@@ -365,8 +365,8 @@
         ui.clearRoomOwner(user.Name, room);
     };
 
-    chat.client.updateRoomCount = function (room, count) {
-        ui.updateLobbyRoomCount(room, count);
+    chat.client.updateRoom = function (room) {
+        ui.updateLobbyRoom(room);
     };
 
     chat.client.markInactive = function (users) {
@@ -577,13 +577,10 @@
         }
     };
 
-    chat.client.changeTopic = function (room) {
-        ui.changeRoomTopic(room);
-    };
+    chat.client.topicChanged = function (roomName, topic, who) {
+        var message,
+            isCleared = (topic === '');
 
-    chat.client.topicChanged = function (roomName, isCleared, topic, who) {
-        var message;
-        
         if (who === ui.getUserName()) {
             if (!isCleared) {
                 message = utility.getLanguageResource('Chat_YouSetRoomTopic', topic);
@@ -599,6 +596,8 @@
         }
 
         ui.addMessage(message, 'notification', roomName);
+        
+        ui.changeRoomTopic(roomName, topic);
     };
 
     chat.client.welcomeChanged = function (isCleared, welcome) {

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -209,7 +209,6 @@
             $topic = $room.find('.topic'),
             roomName = room.Name.toString().toUpperCase();
 
-        $room.css('background-color', '#f5f5f5');
         if (room.Count === 0) {
             $count.text(utility.getLanguageResource('Client_OccupantsZero'));
         } else if (room.Count === 1) {
@@ -242,7 +241,7 @@
         }
 
         // Do a little animation
-        $room.animate({ backgroundColor: '#ffffff' }, 800);
+        $room.css('-webkit-animation-play-state', 'running').css('animation-play-state', 'running');
     }
 
     function addRoomToLobby(roomViewModel) {

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -201,20 +201,21 @@
                      });
     }
 
-    function updateLobbyRoomCount(room, count) {
+    function updateLobbyRoom(room) {
         var lobby = getLobby(),
             $targetList = room.Private === true ? lobby.owners : lobby.users,
             $room = $targetList.find('[data-room="' + room.Name + '"]'),
             $count = $room.find('.count'),
+            $topic = $room.find('.topic'),
             roomName = room.Name.toString().toUpperCase();
 
         $room.css('background-color', '#f5f5f5');
-        if (count === 0) {
+        if (room.Count === 0) {
             $count.text(utility.getLanguageResource('Client_OccupantsZero'));
-        } else if (count === 1) {
+        } else if (room.Count === 1) {
             $count.text(utility.getLanguageResource('Client_OccupantsOne'));
         } else {
-            $count.text(utility.getLanguageResource('Client_OccupantsMany', count));
+            $count.text(utility.getLanguageResource('Client_OccupantsMany', room.Count));
         }
 
         if (room.Private === true) {
@@ -228,10 +229,12 @@
         } else {
             $room.removeClass('closed');
         }
+        
+        $topic.text(room.Topic);
 
-        var nextListElement = getNextRoomListElement($targetList, roomName, count, room.Closed);
+        var nextListElement = getNextRoomListElement($targetList, roomName, room.Count, room.Closed);
 
-        $room.data('count', count);
+        $room.data('count', room.Count);
         if (nextListElement !== null) {
             $room.insertBefore(nextListElement);
         } else {
@@ -635,12 +638,11 @@
         }
     }
 
-    function updateRoomTopic(roomViewModel) {
-        var room = getRoomElements(roomViewModel.Name);
-        var topic = roomViewModel.Topic;
-        var topicHtml = topic === '' ? utility.getLanguageResource('Chat_DefaultTopic', roomViewModel.Name) : ui.processContent(topic);
+    function updateRoomTopic(roomName, topic) {
+        var room = getRoomElements(roomName);
+        var topicHtml = topic === '' ? utility.getLanguageResource('Chat_DefaultTopic', roomName) : ui.processContent(topic);
         var roomTopic = room.roomTopic;
-        var isVisibleRoom = getCurrentRoomElements().getName() === roomViewModel.Name;
+        var isVisibleRoom = getCurrentRoomElements().getName() === roomName;
 
         if (isVisibleRoom) {
             roomTopic.hide();
@@ -1361,7 +1363,7 @@
 
             room.close();
         },
-        updateLobbyRoomCount: updateLobbyRoomCount,
+        updateLobbyRoom: updateLobbyRoom,
         updatePrivateLobbyRooms: function (roomName) {
             var lobby = getLobby(),
                 $room = lobby.users.find('li[data-name="' + roomName + '"]');
@@ -2132,8 +2134,8 @@
 
             updateFlag(userViewModel, $user);
         },
-        changeRoomTopic: function (roomViewModel) {
-            updateRoomTopic(roomViewModel);
+        changeRoomTopic: function (roomName, topic) {
+            updateRoomTopic(roomName, topic);
         },
         confirmMessage: function (id) {
             $('#m-' + id).removeClass('failed')

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -291,10 +291,33 @@ form#send-message {
 
     #userlist-lobby li {
         display: block;
+        animation: room-fade 0.8s linear 1;
+        -webkit-animation: room-fade 0.8s linear 1;
+        animation-play-state: paused;
+        -webkit-animation-play-state: paused;
     }
 
     #userlist-lobby-owners li {
-        display: inline;
+        display: inline-block;
+        margin: 0 5px 10px 5px;
+        height: 102px;
+        animation: room-fade 0.8s linear 1;
+        -webkit-animation: room-fade 0.8s linear 1;
+        animation-play-state: paused;
+        -webkit-animation-play-state: paused;
+    }
+
+    @-webkit-keyframes room-fade
+    {
+        0% { background-color: #FFFFFF; }
+        2% { background-color: #F5F5F5; }
+        100% { background-color: #FFFFFF; }
+    }
+
+    @keyframes room-fade {
+        0% { background-color: #FFFFFF; }
+        2% { background-color: #F5F5F5; }
+        100% { background-color: #FFFFFF; }
     }
 
         #userlist-lobby li.empty,
@@ -361,7 +384,6 @@ form#send-message {
 #userlist-lobby-owners li div.room-row {
     display: inline-block;
     width: 250px;
-    margin: 10px 5px;
     padding: 5px;
     border: 1px solid #e5e5e5;
 }

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -864,6 +864,9 @@ namespace JabbR
             {
                 Clients.Clients(user.GetConnections()).roomClosed(room.Name);
             }
+
+            // notify everyone to update their lobby
+            OnRoomChanged(room);
         }
 
         void INotificationService.UnCloseRoom(IEnumerable<ChatUser> users, ChatRoom room)
@@ -873,6 +876,9 @@ namespace JabbR
             {
                 Clients.Clients(user.GetConnections()).roomUnClosed(room.Name);
             }
+
+            // notify everyone to update their lobby
+            OnRoomChanged(room);
         }
 
         void INotificationService.LogOut(ChatUser user, string clientId)
@@ -990,17 +996,10 @@ namespace JabbR
 
         void INotificationService.ChangeTopic(ChatUser user, ChatRoom room)
         {
-            bool isTopicCleared = String.IsNullOrWhiteSpace(room.Topic);
-            var parsedTopic = room.Topic ?? String.Empty;
-            Clients.Group(room.Name).topicChanged(room.Name, isTopicCleared, parsedTopic, user.Name);
-            // Create the view model
-            var roomViewModel = new RoomViewModel
-            {
-                Name = room.Name,
-                Topic = parsedTopic,
-                Closed = room.Closed
-            };
-            Clients.Group(room.Name).changeTopic(roomViewModel);
+            Clients.Group(room.Name).topicChanged(room.Name, room.Topic ?? String.Empty, user.Name);
+
+            // trigger a lobby update
+            OnRoomChanged(room);
         }
 
         void INotificationService.ChangeWelcome(ChatUser user, ChatRoom room)
@@ -1064,11 +1063,20 @@ namespace JabbR
             {
                 Name = room.Name,
                 Private = room.Private,
-                Closed = room.Closed
+                Closed = room.Closed,
+                Topic = room.Topic ?? String.Empty,
+                Count = _repository.GetOnlineUsers(room).Count()
             };
 
-            // Update the room count
-            Clients.All.updateRoomCount(roomViewModel, _repository.GetOnlineUsers(room).Count());
+            // notify all clients who can see the room
+            if (!room.Private)
+            {
+                Clients.All.updateRoom(roomViewModel);
+            }
+            else
+            {
+                Clients.Clients(_repository.GetAllowedClientIds(room)).updateRoom(roomViewModel);
+            }
         }
 
         private ClientState GetClientState()

--- a/JabbR/Models/RepositoryExtensions.cs
+++ b/JabbR/Models/RepositoryExtensions.cs
@@ -142,5 +142,11 @@ namespace JabbR.Models
         {
             return source.Where(n => n.Room.Name == roomName);
         }
+
+        public static IList<string> GetAllowedClientIds(this IJabbrRepository repository, ChatRoom room)
+        {
+            int[] allowedUserKeys = room.AllowedUsers.Select(u => u.Key).ToArray();
+            return repository.Clients.Where(c => allowedUserKeys.Contains(c.UserKey)).Select(c => c.Id).ToList();
+        }
     }
 }


### PR DESCRIPTION
Previously room topic change wouldn't trigger a refresh in the lobby.  It does now.
- Refactored and made the code that updates the lobby work in more situations (for example, when a room is closed it was not triggering an update).
- Pulled out the (faulty) background colour animation on lobby room update and replaced it with a css animation.
- Ran the topic change through the same code path.

This fixes #971.
