### PR TITLE
Fix nightly references to ones that work

### DIFF
--- a/JabbR.Client.Portable/JabbR.Client.Portable.csproj
+++ b/JabbR.Client.Portable/JabbR.Client.Portable.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.AspNet.SignalR.Client">
-      <HintPath>..\packages\Microsoft.AspNet.SignalR.Client.2.0.0-rtm1-130818-b157\lib\portable-net45+sl5+netcore45+wp8\Microsoft.AspNet.SignalR.Client.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.Client.2.1.0-pre-130916-b211\lib\portable-net45+sl5+netcore45+wp8\Microsoft.AspNet.SignalR.Client.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\portable-net45+wp80+win8\Newtonsoft.Json.dll</HintPath>

--- a/JabbR.Client/JabbR.Client.csproj
+++ b/JabbR.Client/JabbR.Client.csproj
@@ -33,9 +33,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AspNet.SignalR.Client, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.AspNet.SignalR.Client, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.SignalR.Client.2.0.0-rtm1-130818-b157\lib\net40\Microsoft.AspNet.SignalR.Client.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.Client.2.1.0-pre-130916-b211\lib\net40\Microsoft.AspNet.SignalR.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.16\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>

--- a/JabbR.Client/packages.config
+++ b/JabbR.Client/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.SignalR.Client" version="2.0.0-rtm1-130818-b157" targetFramework="net40" />
+  <package id="Microsoft.AspNet.SignalR.Client" version="2.1.0-pre-130916-b211" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.3" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.16" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net40" />

--- a/JabbR.Tests/JabbR.Tests.csproj
+++ b/JabbR.Tests/JabbR.Tests.csproj
@@ -36,17 +36,17 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.0.0-rtm1-130818-b157\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.1.0-pre-130916-b211\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.2.0.0-rtw2-20818-575-dev\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.2.0.1-rtw1-20912-624-dev\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Security, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Security.2.0.0-rtw2-20818-575-dev\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Security.2.0.1-rtw1-20912-624-dev\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>

--- a/JabbR.Tests/packages.config
+++ b/JabbR.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.SignalR.Core" version="2.0.0-rtm1-130818-b157" targetFramework="net45" />
-  <package id="Microsoft.Owin" version="2.0.0-rtw2-20818-575-dev" targetFramework="net45" />
-  <package id="Microsoft.Owin.Security" version="2.0.0-rtw2-20818-575-dev" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.1.0-pre-130916-b211" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="2.0.1-rtw1-20912-624-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security" version="2.0.1-rtw1-20912-624-dev" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" />
   <package id="MSBuildTasks" version="1.4.0.61" targetFramework="net45" />
   <package id="Nancy" version="0.18.0" targetFramework="net45" />

--- a/JabbR.sln
+++ b/JabbR.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.20827.3
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JabbR", "JabbR\JabbR.csproj", "{16204F16-6354-4B68-BB0F-1A4F109FC92B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JabbR.Tests", "JabbR.Tests\JabbR.Tests.csproj", "{45AB4285-8B37-47FD-9D38-40E6BC5D2E13}"
@@ -26,14 +24,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C286B5
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{E4364FCF-C7B4-4346-A890-12C6E4A08A5C}"
-	ProjectSection(SolutionItems) = preProject
-		Build.proj = Build.proj
-		.build\MSBuild.Community.Tasks.dll = .build\MSBuild.Community.Tasks.dll
-		.build\MSBuild.Community.Tasks.targets = .build\MSBuild.Community.Tasks.targets
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JabbR.Client.Portable", "JabbR.Client.Portable\JabbR.Client.Portable.csproj", "{3786FC2E-7FC9-43EC-B137-41B070DE37D8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{F8B28AB9-6B21-40C5-839F-98461F50A5D9}"
+	ProjectSection(SolutionItems) = preProject
+		build.cmd = build.cmd
+		Build\Build.proj = Build\Build.proj
+		Build\MSBuild.Community.Tasks.dll = Build\MSBuild.Community.Tasks.dll
+		Build\MSBuild.Community.Tasks.targets = Build\MSBuild.Community.Tasks.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/JabbR/Infrastructure/JabbRFormsAuthenticationProvider.cs
+++ b/JabbR/Infrastructure/JabbRFormsAuthenticationProvider.cs
@@ -150,5 +150,10 @@ namespace JabbR.Infrastructure
 
             return null;
         }
+
+        public void ApplyRedirect(CookieApplyRedirectContext context)
+        {
+            context.Response.Redirect(context.RedirectUri);
+        }
     }
 }

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -79,12 +79,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.0.0-rtm1-130818-b157\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.1.0-pre-130916-b211\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.SystemWeb">
-      <HintPath>..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.0.0-rtm1-130818-b157\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.1.0-pre-130916-b211\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -95,37 +97,37 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Data.OData.5.6.0-rc1\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.2.0.0-rtw2-20818-575-dev\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.2.0.1-rtw1-20912-624-dev\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Diagnostics, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Diagnostics, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Diagnostics.2.0.0-rtw2-20818-575-dev\lib\net40\Microsoft.Owin.Diagnostics.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Diagnostics.2.0.1-rtw1-20912-624-dev\lib\net40\Microsoft.Owin.Diagnostics.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.FileSystems, Version=0.24.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.FileSystems, Version=0.26.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.FileSystems.0.24.0-pre-20818-575-dev\lib\net40\Microsoft.Owin.FileSystems.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.FileSystems.0.26.0-pre-20912-624-dev\lib\net40\Microsoft.Owin.FileSystems.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.2.0.0-rtw2-20818-575-dev\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.2.0.1-rtw1-20912-624-dev\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Security, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Security.2.0.0-rtw2-20818-575-dev\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Security.2.0.1-rtw1-20912-624-dev\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Cookies, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Security.Cookies, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.2.0.0-rtw2-20818-575-dev\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.2.0.1-rtw1-20912-624-dev\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Security.Federation, Version=0.24.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.Security.Federation.0.24.0-pre-20725-492-rel\lib\net45\Microsoft.Owin.Security.Federation.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.Security.Federation.0.24.0-pre-20725-492-dev\lib\net45\Microsoft.Owin.Security.Federation.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.StaticFiles, Version=0.24.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.StaticFiles, Version=0.26.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.StaticFiles.0.24.0-pre-20818-575-dev\lib\net40\Microsoft.Owin.StaticFiles.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.StaticFiles.0.26.0-pre-20916-628-dev\lib\net45\Microsoft.Owin.StaticFiles.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JabbR/packages.config
+++ b/JabbR/packages.config
@@ -12,22 +12,22 @@
   <package id="jquery.keytips" version="1.0.6" targetFramework="net40" />
   <package id="jQuery.Templates" version="0.1" />
   <package id="json2" version="1.0.2" targetFramework="net40" />
-  <package id="Microsoft.AspNet.SignalR" version="2.0.0-rtm1-130818-b157" targetFramework="net45" />
-  <package id="Microsoft.AspNet.SignalR.Core" version="2.0.0-rtm1-130818-b157" targetFramework="net45" />
-  <package id="Microsoft.AspNet.SignalR.JS" version="2.0.0-rtm1-130818-b157" targetFramework="net45" />
-  <package id="Microsoft.AspNet.SignalR.SystemWeb" version="2.0.0-rtm1-130818-b157" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR" version="2.1.0-pre-130916-b211" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.1.0-pre-130916-b211" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.JS" version="2.1.0-pre-130916-b211" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.SystemWeb" version="2.1.0-pre-130916-b211" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.0.0-rc1-130807" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.0.0-rc1-130807" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0-rc1" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0-rc1" targetFramework="net45" />
-  <package id="Microsoft.Owin" version="2.0.0-rtw2-20818-575-dev" targetFramework="net45" />
-  <package id="Microsoft.Owin.Diagnostics" version="2.0.0-rtw2-20818-575-dev" targetFramework="net45" />
-  <package id="Microsoft.Owin.FileSystems" version="0.24.0-pre-20818-575-dev" targetFramework="net45" />
-  <package id="Microsoft.Owin.Host.SystemWeb" version="2.0.0-rtw2-20818-575-dev" targetFramework="net45" />
-  <package id="Microsoft.Owin.Security" version="2.0.0-rtw2-20818-575-dev" targetFramework="net45" />
-  <package id="Microsoft.Owin.Security.Cookies" version="2.0.0-rtw2-20818-575-dev" targetFramework="net45" />
-  <package id="Microsoft.Owin.Security.Federation" version="0.24.0-pre-20725-492-rel" targetFramework="net45" />
-  <package id="Microsoft.Owin.StaticFiles" version="0.24.0-pre-20818-575-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="2.0.1-rtw1-20912-624-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin.Diagnostics" version="2.0.1-rtw1-20912-624-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin.FileSystems" version="0.26.0-pre-20912-624-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="2.0.1-rtw1-20912-624-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security" version="2.0.1-rtw1-20912-624-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security.Cookies" version="2.0.1-rtw1-20912-624-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security.Federation" version="0.24.0-pre-20725-492-dev" targetFramework="net45" />
+  <package id="Microsoft.Owin.StaticFiles" version="0.26.0-pre-20916-628-dev" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.1.0" targetFramework="net45" />
   <package id="Nancy" version="0.18.0" targetFramework="net45" />
   <package id="Nancy.Bootstrappers.Ninject" version="0.18.0" targetFramework="net45" />

--- a/build.cmd
+++ b/build.cmd
@@ -5,4 +5,4 @@ if "%config%" == "" (
 )
 
 .nuget\NuGet.exe restore JabbR.sln
-msbuild %~dp0\Build\Build.proj /p:Configuration="%config%" /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
+msbuild %~dp0\Build\Build.proj /p:Configuration="%config%" /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false /p:VisualStudioVersion=11.0


### PR DESCRIPTION
Fix nuget refs, build folder in sln (which referred to nonexistent files), add vs version to build.cmd to support building from cmdline again, implement newly required applyredirect in formsauthenticationprovider.
