### PR TITLE
Fix #979 - Add ui content processing to topics shown in lobby

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -201,13 +201,14 @@
             $room = $targetList.find('[data-room="' + room.Name + '"]'),
             $count = $room.find('.count'),
             $topic = $room.find('.topic'),
-            roomName = room.Name.toString().toUpperCase();
+            roomName = room.Name.toString().toUpperCase(),
+            processedTopic = ui.processContent(room.Topic);
         
         // if we don't find the room, we need to create it
         if ($room.length === 0) {
             addRoomToLobby(room);
             return;
-        }
+        }           
 
         if (room.Count === 0) {
             $count.text(utility.getLanguageResource('Client_OccupantsZero'));
@@ -228,8 +229,8 @@
         } else {
             $room.removeClass('closed');
         }
-        
-        $topic.text(room.Topic);
+
+        $topic.html(processedTopic);
 
         var nextListElement = getNextRoomListElement($targetList, roomName, room.Count, room.Closed);
 
@@ -246,13 +247,16 @@
 
     function addRoomToLobby(roomViewModel) {
         var lobby = getLobby(),
-            $room = templates.lobbyroom.tmpl(roomViewModel),
+            $room = null,
             roomName = roomViewModel.Name.toString().toUpperCase(),
             count = roomViewModel.Count,
             closed = roomViewModel.Closed,
             nonPublic = roomViewModel.Private,
             $targetList = roomViewModel.Private ? lobby.owners : lobby.users,
             i = null;
+
+        roomViewModel.ProcessedTopic = ui.processContent(roomViewModel.Topic);
+        $room = templates.lobbyroom.tmpl(roomViewModel);
 
         var nextListElement = getNextRoomListElement($targetList, roomName, count, closed);
 
@@ -1465,6 +1469,15 @@
             var lobby = getLobby(),
                 i;
             if (!lobby.isInitialized()) {
+                
+                // Process the topics
+                for (i = 0; i < rooms.length; ++i) {
+                    rooms[i].ProcessedTopic = ui.processContent(rooms[i].Topic);
+                }
+                
+                for (i = 0; i < privateRooms.length; ++i) {
+                    privateRooms[i].ProcessedTopic = ui.processContent(privateRooms[i].Topic);
+                }
 
                 // Populate the room cache
                 for (i = 0; i < rooms.length; ++i) {

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -255,7 +255,7 @@
             $targetList = roomViewModel.Private ? lobby.owners : lobby.users,
             i = null;
 
-        roomViewModel.ProcessedTopic = ui.processContent(roomViewModel.Topic);
+        roomViewModel.processedTopic = ui.processContent(roomViewModel.Topic);
         $room = templates.lobbyroom.tmpl(roomViewModel);
 
         var nextListElement = getNextRoomListElement($targetList, roomName, count, closed);
@@ -1472,11 +1472,11 @@
                 
                 // Process the topics
                 for (i = 0; i < rooms.length; ++i) {
-                    rooms[i].ProcessedTopic = ui.processContent(rooms[i].Topic);
+                    rooms[i].processedTopic = ui.processContent(rooms[i].Topic);
                 }
                 
                 for (i = 0; i < privateRooms.length; ++i) {
-                    privateRooms[i].ProcessedTopic = ui.processContent(privateRooms[i].Topic);
+                    privateRooms[i].processedTopic = ui.processContent(privateRooms[i].Topic);
                 }
 
                 // Populate the room cache

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -103,7 +103,7 @@
                     <span class="readonly"><i class="icon-ban-circle"></i></span>
                 </div>
                 <div class="span4">
-                    <span class="topic">${Topic}</span>
+                    <span class="topic">{{html ProcessedTopic}}</span>
                 </div>
                 <div class="span2">
                     <span class="count">

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -103,7 +103,7 @@
                     <span class="readonly"><i class="icon-ban-circle"></i></span>
                 </div>
                 <div class="span4">
-                    <span class="topic">{{html ProcessedTopic}}</span>
+                    <span class="topic">{{html processedTopic}}</span>
                 </div>
                 <div class="span2">
                     <span class="count">


### PR DESCRIPTION
Now when users put :love_hotel: or :trollface: in the topic, it'll be correctly displayed on the lobby page.

Fixes #979
