### PR TITLE
Fix #994 - the display of second page of rooms on lobby screen was broken

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1473,7 +1473,7 @@
                 }
 
                 var listOfRooms = $('<ul/>');
-                populateLobbyRoomList(sortedRoomList.splice(0, maxRoomsToLoad), templates.lobbyroom, listOfRooms);
+                populateLobbyRoomList(sortedRoomList.slice(0, maxRoomsToLoad), templates.lobbyroom, listOfRooms);
                 lastLoadedRoomIndex = listOfRooms.children('li').length;
                 listOfRooms.children('li').appendTo(lobby.users);
                 if (lastLoadedRoomIndex < sortedRoomList.length) {


### PR DESCRIPTION
When you clicked Load More on the lobby screen, it would skip the second page of results (results 101-200) and skip straight to 201-300.  Subsequent clicks would however work.
