### PR TITLE
Improve various things around the lobby and room list functionality

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -372,13 +372,17 @@
         performLogout();
     };
 
-    chat.client.lockRoom = function (user, room) {
+    chat.client.lockRoom = function (user, room, userHasAccess) {
         if (!isSelf(user) && this.state.activeRoom === room) {
             ui.addMessage(utility.getLanguageResource('Chat_UserLockedRoom', user.Name, room), 'notification', this.state.activeRoom);
         }
 
-        ui.setRoomLocked(room);
-        ui.updatePrivateLobbyRooms(room);
+        if (userHasAccess) {
+            ui.setRoomLocked(room);
+            ui.updatePrivateLobbyRooms(room);
+        } else {
+            ui.removeLobbyRoom(room);
+        }
     };
 
     // Called when this user locked a room
@@ -503,16 +507,20 @@
 
     // User single client commands
 
-    chat.client.allowUser = function (room) {
+    chat.client.allowUser = function (room, roomInfo) {
         ui.addMessage(utility.getLanguageResource('Chat_YouGrantedRoomAccess', room), 'notification', this.state.activeRoom);
+
+        ui.updateLobbyRoom(roomInfo);
     };
 
     chat.client.userAllowed = function (user, room) {
         ui.addMessage(utility.getLanguageResource('Chat_UserGrantedRoomAccess', user, room), 'notification', this.state.activeRoom);
     };
 
-    chat.client.unallowUser = function (user, room) {
+    chat.client.unallowUser = function (room) {
         ui.addMessage(utility.getLanguageResource('Chat_YourRoomAccessRevoked', room), 'notification', this.state.activeRoom);
+
+        ui.removeLobbyRoom(room);
     };
 
     chat.client.userUnallowed = function (user, room) {

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1949,7 +1949,9 @@
             return ui.commands || [];
         },
         setCommands: function (commands) {
-            ui.commands = commands;
+            ui.commands = commands.sort(function(a, b) {
+                 return a.Name.toUpperCase().localeCompare(b.Name.toUpperCase());
+            });
             
             $globalCmdHelp.empty();
             $roomCmdHelp.empty();

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1230,6 +1230,9 @@
                                              }
 
                                              return '';
+                                         })
+                                         .sort(function(a, b) {
+                                             return a.toString().toUpperCase().localeCompare(b.toString().toUpperCase());
                                          });
                         case '#':
                             return getRoomsNames();
@@ -1950,7 +1953,7 @@
         },
         setCommands: function (commands) {
             ui.commands = commands.sort(function(a, b) {
-                 return a.Name.toUpperCase().localeCompare(b.Name.toUpperCase());
+                return a.Name.toString().toUpperCase().localeCompare(b.Name.toString().toUpperCase());
             });
             
             $globalCmdHelp.empty();

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1506,6 +1506,34 @@
             // re-filter lists
             $lobbyRoomFilterForm.submit();
         },
+        removeLobbyRoom: function (roomName) {
+            var roomNameUppercase = roomName.toString().toUpperCase();
+            
+            if (roomCache[roomNameUppercase]) {
+                delete roomCache[roomNameUppercase];
+            }
+            
+            // find the element in the sorted room list and remove it
+            for (var i = 0; i < sortedRoomList.length; i++) {
+                if (sortedRoomList[i].Name.toString().toUpperCase().localeCompare(roomNameUppercase) === 0) {
+                    sortedRoomList.splice(i, 1);
+                    break;
+                }
+            }
+            
+            // find the element in the lobby public room list and remove it
+            for (var i = 0; i < publicRoomList.length; i++) {
+                if (publicRoomList[i].Name.toString().toUpperCase().localeCompare(roomNameUppercase) === 0) {
+                    publicRoomList.splice(i, 1);
+                    break;
+                }
+            }
+            
+            // remove the items from the lobby screen
+            var lobby = getLobby(),
+                $room = lobby.users.add(lobby.owners).find('[data-room="' + roomName + '"]');
+            $room.remove();
+        },
         addUser: function (userViewModel, roomName) {
             var room = getRoomElements(roomName),
                 $user = null,

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -202,6 +202,12 @@
             $count = $room.find('.count'),
             $topic = $room.find('.topic'),
             roomName = room.Name.toString().toUpperCase();
+        
+        // if we don't find the room, we need to create it
+        if ($room.length == 0) {
+            addRoomToLobby(room);
+            return;
+        }
 
         if (room.Count === 0) {
             $count.text(utility.getLanguageResource('Client_OccupantsZero'));
@@ -255,6 +261,21 @@
         }
 
         filterIndividualRoom($room);
+        lobby.setListState($targetList);
+        
+        roomCache[roomName.toString().toUpperCase()] = true;
+
+        // don't try to populate the sortedRoomList while we're initially filling up the lobby
+        if (sortedRoomList) {
+            var sortedRoomInsertIndex = sortedRoomList.length;
+            for (var i = 0; i < sortedRoomList.length; i++) {
+                if (sortedRoomList[i].Name.toString().toUpperCase().localeCompare(roomName) > 0) {
+                    sortedRoomInsertIndex = i;
+                    break;
+                }
+            }
+            sortedRoomList.splice(sortedRoomInsertIndex, 0, roomViewModel);
+        }
     }
     
     function getNextRoomListElement($targetList, roomName, count, closed) {
@@ -342,8 +363,6 @@
         if (!roomCache[roomName.toString().toUpperCase()]) {
             addRoomToLobby(roomViewModel);
         }
-
-        roomCache[roomName.toString().toUpperCase()] = true;
         
         templates.tab.tmpl(viewModel).data('name', roomName).appendTo($tabsDropdown);
         ui.updateTabOverflow();

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1132,11 +1132,6 @@
                 var room = getCurrentRoomElements(),
                     $lobbyRoomsLists = $lobbyPrivateRooms.add($lobbyOtherRooms);
 
-                // bounce on any room other than lobby
-                if (!room.isLobby()) {
-                    return false;
-                }
-
                 // hide all elements except those that match the input / closed filters
                 $lobbyRoomsLists
                     .find('li:not(.empty)')

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -264,7 +264,7 @@
         filterIndividualRoom($room);
         lobby.setListState($targetList);
         
-        roomCache[roomName.toString().toUpperCase()] = true;
+        roomCache[roomName] = true;
 
         // don't try to populate the sortedRoomList while we're initially filling up the lobby
         if (sortedRoomList) {
@@ -276,6 +276,16 @@
                 }
             }
             sortedRoomList.splice(sortedRoomInsertIndex, 0, roomViewModel);
+        }
+        
+        // handle updates on rooms not currently displayed to clients by removing from the public room list
+        if (publicRoomList) {
+            for (var i = 0; i < publicRoomList.length; i++) {
+                if (publicRoomList[i].Name.toString().toUpperCase().localeCompare(roomName) === 0) {
+                    publicRoomList.splice(i, 1);
+                    break;
+                }
+            }
         }
         
         // if it's a private room, make sure that we're displaying the private room section

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -250,6 +250,7 @@
             roomName = roomViewModel.Name.toString().toUpperCase(),
             count = roomViewModel.Count,
             closed = roomViewModel.Closed,
+            nonPublic = roomViewModel.Private,
             $targetList = roomViewModel.Private ? lobby.owners : lobby.users;
 
         var nextListElement = getNextRoomListElement($targetList, roomName, count, closed);
@@ -275,6 +276,12 @@
                 }
             }
             sortedRoomList.splice(sortedRoomInsertIndex, 0, roomViewModel);
+        }
+        
+        // if it's a private room, make sure that we're displaying the private room section
+        if (nonPublic) {
+            $lobbyPrivateRooms.show();
+            $lobbyOtherRooms.find('.nav-header').html(utility.getLanguageResource('Client_OtherRooms'));
         }
     }
     
@@ -1482,10 +1489,10 @@
                     populateLobbyRoomList(privateSorted, templates.lobbyroom, listOfPrivateRooms);
                     listOfPrivateRooms.children('li').appendTo(lobby.owners);
                     $lobbyPrivateRooms.show();
-                    $lobbyOtherRooms.find('nav-header').html(utility.getLanguageResource('Client_OtherRooms'));
+                    $lobbyOtherRooms.find('.nav-header').html(utility.getLanguageResource('Client_OtherRooms'));
                 } else {
                     $lobbyPrivateRooms.hide();
-                    $lobbyOtherRooms.find('nav-header').html(utility.getLanguageResource('Client_Rooms'));
+                    $lobbyOtherRooms.find('.nav-header').html(utility.getLanguageResource('Client_Rooms'));
                 }
 
                 var listOfRooms = $('<ul/>');
@@ -1533,6 +1540,12 @@
             var lobby = getLobby(),
                 $room = lobby.users.add(lobby.owners).find('[data-room="' + roomName + '"]');
             $room.remove();
+            
+            // if we have no private rooms, hide the private rooms section and change the text on the rooms header
+            if (lobby.owners.find('li:not(.empty)').length <= 1) {
+                $lobbyPrivateRooms.hide();
+                $lobbyOtherRooms.find('.nav-header').html(utility.getLanguageResource('Client_Rooms'));
+            }
         },
         addUser: function (userViewModel, roomName) {
             var room = getRoomElements(roomName),

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -204,7 +204,7 @@
             roomName = room.Name.toString().toUpperCase();
         
         // if we don't find the room, we need to create it
-        if ($room.length == 0) {
+        if ($room.length === 0) {
             addRoomToLobby(room);
             return;
         }
@@ -251,7 +251,8 @@
             count = roomViewModel.Count,
             closed = roomViewModel.Closed,
             nonPublic = roomViewModel.Private,
-            $targetList = roomViewModel.Private ? lobby.owners : lobby.users;
+            $targetList = roomViewModel.Private ? lobby.owners : lobby.users,
+            i = null;
 
         var nextListElement = getNextRoomListElement($targetList, roomName, count, closed);
 
@@ -269,7 +270,7 @@
         // don't try to populate the sortedRoomList while we're initially filling up the lobby
         if (sortedRoomList) {
             var sortedRoomInsertIndex = sortedRoomList.length;
-            for (var i = 0; i < sortedRoomList.length; i++) {
+            for (i = 0; i < sortedRoomList.length; i++) {
                 if (sortedRoomList[i].Name.toString().toUpperCase().localeCompare(roomName) > 0) {
                     sortedRoomInsertIndex = i;
                     break;
@@ -280,7 +281,7 @@
         
         // handle updates on rooms not currently displayed to clients by removing from the public room list
         if (publicRoomList) {
-            for (var i = 0; i < publicRoomList.length; i++) {
+            for (i = 0; i < publicRoomList.length; i++) {
                 if (publicRoomList[i].Name.toString().toUpperCase().localeCompare(roomName) === 0) {
                     publicRoomList.splice(i, 1);
                     break;
@@ -1524,14 +1525,15 @@
             $lobbyRoomFilterForm.submit();
         },
         removeLobbyRoom: function (roomName) {
-            var roomNameUppercase = roomName.toString().toUpperCase();
+            var roomNameUppercase = roomName.toString().toUpperCase(),
+                i = null;
             
             if (roomCache[roomNameUppercase]) {
                 delete roomCache[roomNameUppercase];
             }
             
             // find the element in the sorted room list and remove it
-            for (var i = 0; i < sortedRoomList.length; i++) {
+            for (i = 0; i < sortedRoomList.length; i++) {
                 if (sortedRoomList[i].Name.toString().toUpperCase().localeCompare(roomNameUppercase) === 0) {
                     sortedRoomList.splice(i, 1);
                     break;
@@ -1539,7 +1541,7 @@
             }
             
             // find the element in the lobby public room list and remove it
-            for (var i = 0; i < publicRoomList.length; i++) {
+            for (i = 0; i < publicRoomList.length; i++) {
                 if (publicRoomList[i].Name.toString().toUpperCase().localeCompare(roomNameUppercase) === 0) {
                     publicRoomList.splice(i, 1);
                     break;


### PR DESCRIPTION
Improve various things around the lobby and room list functionality.
- [x] Sort room list for autocomplete
- [x] Enable autocomplete on all rooms (not just those in the lobby list)
- [x] Fix issue with closed rooms appearing in lobby if the initial tab is a room
- [x] Add newly created rooms to all users' lobby lists
- [x] Remove rooms from public lobby roomlist when locked (including hidden behind load-more button list)
- [x] Remove rooms from private room list on unallow
- [x] Add rooms to user's private room list on allow
- [x] Fix rooms header to change to 'other rooms' when nonpublic room(s) are present
- [x] Show/hide private rooms list when the first private room is added or the last private room is removed
