### PR TITLE
Escape meme

### DIFF
--- a/JabbR.Tests/CommandManagerFacts.cs
+++ b/JabbR.Tests/CommandManagerFacts.cs
@@ -5215,6 +5215,40 @@ namespace JabbR.Test
             }
 
             [Fact]
+            public void EncodesSpecialCharacters()
+            {
+                // Arrange.
+                var repository = new InMemoryRepository();
+                var cache = new Mock<ICache>().Object;
+                var user = new ChatUser
+                {
+                    Name = "asshat",
+                    Id = "1"
+                };
+                repository.Add(user);
+                var room = new ChatRoom
+                {
+                    Name = "room"
+                };
+                repository.Add(room);
+                var service = new ChatService(cache, new Mock<IRecentMessageCache>().Object, repository);
+                var notificationService = new Mock<INotificationService>();
+                var commandManager = new CommandManager("clientid",
+                                                        "1",
+                                                        "room",
+                                                        service,
+                                                        repository,
+                                                        cache,
+                                                        notificationService.Object);
+                // Act.
+                bool result = commandManager.TryHandleCommand("/meme ramsay cold-hands? type-faster/!...");
+
+                // Assert.
+                Assert.True(result);
+                notificationService.Verify(x => x.GenerateMeme(user, room, "https://upboat.me/ramsay/cold-hands%3F/type-faster%2F!....jpg"), Times.Once());
+            }
+
+            [Fact]
             public void InLobbyThrows()
             {
                 // Arrange.

--- a/JabbR/Commands/MemeCommand.cs
+++ b/JabbR/Commands/MemeCommand.cs
@@ -25,7 +25,9 @@ namespace JabbR.Commands
             }
 
             ChatRoom callingRoom = context.Repository.GetRoomByName(callerContext.RoomName);
-            string message = String.Format("https://upboat.me/{0}/{1}/{2}.jpg", args[0], args[1], args[2]);
+            string topLine = Uri.EscapeDataString(args[1]);
+            string bottomLine = Uri.EscapeDataString(args[2]);
+            string message = String.Format("https://upboat.me/{0}/{1}/{2}.jpg", args[0], topLine, bottomLine);
 
             context.NotificationService.GenerateMeme(callingUser, callingRoom, message);
         }


### PR DESCRIPTION
Fixes #1012 - encode a bunch of characters (like question marks, slashes, hash characters) to make meme generation better.
