### PR TITLE
defer writing messages and handing commands from the hub to the ui tier until the room in question is ready.

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1958,27 +1958,24 @@
                 $middle.append(content);
             }
         },
-        getAllOpenRooms: function() {
-            var rooms = getAllRoomElements();
+        getOpenRoomNames: function() {
+            var openRooms = $.grep(getAllRoomElements(), function(elem) {
+                return (elem.getName() !== undefined && elem.isClosed() === false);
+            });
 
-            for (var r in rooms) {
-                if (rooms[r].getName() !== undefined && rooms[r].isClosed() === false) {
-                    
-                }
-            }
+            return $.map(openRooms, function(elem) {
+                return elem.getName();
+            });
         },
         addPrivateMessage: function (content, type) {
-            var rooms = getAllRoomElements();
+            var openRooms = this.getOpenRoomNames(),
+                _this = this;
             
-            // todo: I think that this should be in chat.js
-            for (var r in rooms) {
-                if (rooms[r].getName() !== undefined && rooms[r].isClosed() === false) {
-                    var _this = this;
-                    this.awaitRoomReady(rooms[r].getName(), this, function() {
-                        _this.addMessage(content, type, rooms[r].getName());
-                    });
-                }
-            }
+            $.each(openRooms, function (idx, elem) {
+                _this.awaitRoomReady(elem, _this, function() {
+                    _this.addMessage(content, type, elem);
+                });
+            });
         },
         prepareNotificationMessage: function (options, type) {
             if (typeof options === 'string') {


### PR DESCRIPTION
Should\* work.  Does stuff like ensures that we don't dup messages that get received between when the client calls logOn and when they actually getRoomInfo (and makes sure that the non-dup messages actually appear correctly in history).

*Should work at least as well as what's in there at the moment.  Though it's less performant because we closure all over the place
