### PR TITLE
Fix being able to get to negative unread notifications count.  Fixes #1031

### DIFF
--- a/JabbR/notifications.js
+++ b/JabbR/notifications.js
@@ -16,6 +16,7 @@
         if ($this.hasClass('disabled')) {
             return false;
         }
+        $this.addClass('disabled');
 
         $.publish('notifications.mark', [{ url: dataUrl, notificationId: notificationId }]);
     });


### PR DESCRIPTION
When you click on the "I've read this" button, it decrements the unread notifications count by 1.  You can currently click on the button multiple times while the notification is hiding.  This change marks the notification read thing as disabled preventing the second click from triggering the decrement event.
