### PR TITLE
Fixed name matching regex for mentions

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -215,7 +215,7 @@
     }
 
     function getMessageViewModel(message) {
-        var re = new RegExp("\\b@?" + chat.state.name.replace(/\./, '\\.') + "\\b", "i");
+        var re = new RegExp("\\b@?" + chat.state.name.replace(/\./g, '\\.') + "\\b", "i");
         return {
             name: message.User.Name,
             hash: message.User.Hash,


### PR DESCRIPTION
- Original name matching regex only replaced the first
  . character instead of all of them
