### PR TITLE
Add SQL scaleout for signalr

### DIFF
--- a/JabbR/App_Start/Startup.cs
+++ b/JabbR/App_Start/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.IO;
 using System.Net.Http.Formatting;
 using System.Web.Http;
@@ -183,6 +184,11 @@ namespace JabbR
                 };
 
                 resolver.UseServiceBus(sbConfig);
+            }
+
+            if (jabbrConfig.ScaleOutSqlServer)
+            {
+                resolver.UseSqlServer(ConfigurationManager.ConnectionStrings["Jabbr"].ConnectionString);
             }
 
             kernel.Bind<IConnectionManager>()

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -87,8 +87,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.SignalR.ServiceBus.2.1.0-pre-131015-b246\lib\net45\Microsoft.AspNet.SignalR.ServiceBus.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.SignalR.SqlServer">
-      <HintPath>..\packages\Microsoft.AspNet.SignalR.SqlServer.2.0.0\lib\net45\Microsoft.AspNet.SignalR.SqlServer.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.SignalR.SqlServer, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.SqlServer.2.1.0-pre-131015-b246\lib\net45\Microsoft.AspNet.SignalR.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.SystemWeb, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -87,6 +87,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.SignalR.ServiceBus.2.1.0-pre-131015-b246\lib\net45\Microsoft.AspNet.SignalR.ServiceBus.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNet.SignalR.SqlServer">
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.SqlServer.2.0.0\lib\net45\Microsoft.AspNet.SignalR.SqlServer.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.SystemWeb, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.1.0-pre-131015-b246\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>

--- a/JabbR/Services/IJabbrConfiguration.cs
+++ b/JabbR/Services/IJabbrConfiguration.cs
@@ -16,5 +16,7 @@ namespace JabbR.Services
 
         string ServiceBusConnectionString { get; }
         string ServiceBusTopicPrefix { get; }
+
+        bool ScaleOutSqlServer { get; }
     }
 }

--- a/JabbR/Services/JabbrConfiguration.cs
+++ b/JabbR/Services/JabbrConfiguration.cs
@@ -72,5 +72,19 @@ namespace JabbR.Services
                 return ConfigurationManager.AppSettings["jabbr:serviceBusTopicPrefix"];
             }
         }
+        
+        public bool ScaleOutSqlServer
+        {
+            get
+            {
+                string scaleOutSqlServerValue = ConfigurationManager.AppSettings["jabbr:scaleOutSqlServer"];
+                bool scaleOutSqlServer;
+                if (Boolean.TryParse(scaleOutSqlServerValue, out scaleOutSqlServer))
+                {
+                    return scaleOutSqlServer;
+                }
+                return false;
+            }
+        }
     }
 }

--- a/JabbR/Web.config
+++ b/JabbR/Web.config
@@ -35,6 +35,8 @@
     <!-- Serivce bus scale out support -->
     <add key="jabbr:serviceBusConnectionString" value="" />
     <add key="jabbr:serviceBusTopicPrefix" value="" />
+    <!-- Sql Server scale out support -->
+    <add key="jabbr:scaleOutSqlServer" value="false" />
     <add key="NewRelic.AppName" value="JabbR" />
   </appSettings>
   <system.web>
@@ -90,6 +92,10 @@
       <dependentAssembly>
         <assemblyIdentity name="AjaxMin" publicKeyToken="21ef50ce11b5d80f" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.97.4951.28478" newVersion="4.97.4951.28478" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNet.SignalR.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/JabbR/Web.config
+++ b/JabbR/Web.config
@@ -93,10 +93,6 @@
         <assemblyIdentity name="AjaxMin" publicKeyToken="21ef50ce11b5d80f" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.97.4951.28478" newVersion="4.97.4951.28478" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.AspNet.SignalR.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/JabbR/packages.config
+++ b/JabbR/packages.config
@@ -16,6 +16,7 @@
   <package id="Microsoft.AspNet.SignalR.Core" version="2.1.0-pre-131015-b246" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.JS" version="2.1.0-pre-131015-b246" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.ServiceBus" version="2.1.0-pre-131015-b246" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.SqlServer" version="2.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.SystemWeb" version="2.1.0-pre-131015-b246" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.0-alpha1-131015" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.0-alpha1-131015" targetFramework="net45" />

--- a/JabbR/packages.config
+++ b/JabbR/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.AspNet.SignalR.Core" version="2.1.0-pre-131015-b246" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.JS" version="2.1.0-pre-131015-b246" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.ServiceBus" version="2.1.0-pre-131015-b246" targetFramework="net45" />
-  <package id="Microsoft.AspNet.SignalR.SqlServer" version="2.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.SignalR.SqlServer" version="2.1.0-pre-131015-b246" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.SystemWeb" version="2.1.0-pre-131015-b246" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.0-alpha1-131015" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.1.0-alpha1-131015" targetFramework="net45" />


### PR DESCRIPTION
Only supporting the azure service bus backplane for scaleout is lame (and means that we can't test locally).
