### PR TITLE
Refactored LINQ to shorter, faster statement in PersistedRepository.IsUs...

### DIFF
--- a/JabbR/Services/PersistedRepository.cs
+++ b/JabbR/Services/PersistedRepository.cs
@@ -295,9 +295,7 @@ namespace JabbR.Services
             return _db.Entry(user)
                       .Collection(r => r.Rooms)
                       .Query()
-                      .Where(r => r.Key == room.Key)
-                      .Select(r => r.Name)
-                      .FirstOrDefault() != null;
+                      .Any(r => r.Key == room.Key);
         }
 
         public void Reload(object entity)


### PR DESCRIPTION
I don't see any reason why this statement can't be refactored as below.

There are no integration tests to support my claim, but there is no explicitly assigning null to room name anywhere in the project--for this application's purpose, these should work the same from what I can see (and the manual testing I did).

An absolutely equivalent statement should be .Any(r => r.Key == room.Key && r.Name != null) which is still more concise and only returns a bit from the db--rather than the full name of the room (which is totally unnecessary here, even if my PR isn't the optimal refactor :scream:).  

Curious as to whether or not this is an EF optimization trick, but there are usually comments in the codebase for such quirks.

I wouldn't obsess over this if it weren't a very frequent call.
