### PR TITLE
Fix in room cache

### DIFF
--- a/JabbR/App_Start/Startup.DependencyInjection.cs
+++ b/JabbR/App_Start/Startup.DependencyInjection.cs
@@ -102,8 +102,21 @@ namespace JabbR
                   .To<JabbRAuthenticationCallbackProvider>();
 
             kernel.Bind<ICache>()
+                  .To<CacheProxy>()
+                  .InSingletonScope();
+
+            // singleton defaultcache across multiple bindings
+            kernel.Bind<DefaultCache>()
                   .To<DefaultCache>()
                   .InSingletonScope();
+
+            kernel.Bind<ICache>()
+                  .ToMethod(k => k.Kernel.Get<DefaultCache>())
+                  .WhenInjectedInto<CacheProxy>();
+
+            kernel.Bind<ICache>()
+                  .ToMethod(k => k.Kernel.Get<DefaultCache>())
+                  .WhenInjectedInto<ISettingsManager>();
 
             kernel.Bind<IChatNotificationService>()
                   .To<ChatNotificationService>();

--- a/JabbR/App_Start/Startup.cs
+++ b/JabbR/App_Start/Startup.cs
@@ -156,11 +156,8 @@ namespace JabbR
             var hubPipeline = resolver.Resolve<IHubPipeline>();
             var configuration = resolver.Resolve<IConfigurationManager>();
 
-            bool hasBackplane = false;
-
             // Enable service bus scale out
-            if (!String.IsNullOrEmpty(jabbrConfig.ServiceBusConnectionString) &&
-                !String.IsNullOrEmpty(jabbrConfig.ServiceBusTopicPrefix))
+            if (jabbrConfig.ScaleOutServiceBus)
             {
                 var sbConfig = new ServiceBusScaleoutConfiguration(jabbrConfig.ServiceBusConnectionString,
                                                                    jabbrConfig.ServiceBusTopicPrefix)
@@ -169,16 +166,14 @@ namespace JabbR
                 };
 
                 resolver.UseServiceBus(sbConfig);
-                hasBackplane = true;
             }
 
             if (jabbrConfig.ScaleOutSqlServer)
             {
                 resolver.UseSqlServer(jabbrConfig.SqlConnectionString.ConnectionString);
-                hasBackplane = true;
             }
 
-            if (hasBackplane)
+            if (jabbrConfig.ScaleOut)
             {
                 kernel.Bind<IBackplaneMethodResolver>().To<BackplaneReflectionMethodResolver>();
 

--- a/JabbR/Infrastructure/BackplaneChannel.cs
+++ b/JabbR/Infrastructure/BackplaneChannel.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Microsoft.AspNet.SignalR.Infrastructure;
+using Microsoft.AspNet.SignalR.Json;
+using Microsoft.AspNet.SignalR.Messaging;
+
+using Newtonsoft.Json;
+
+namespace JabbR.Infrastructure
+{
+    public class BackplaneChannel : ISubscriber, IBackplaneChannel
+    {
+        private const string BackplaneSignal = "__BACKPLANE__";
+
+        private readonly List<string> _signals = new List<string>{ BackplaneSignal };
+
+        private readonly JsonSerializer _jsonSerializer;
+
+        private readonly IServerIdManager _serverIdManager;
+
+        private readonly IMessageBus _messageBus;
+
+        private readonly IEnumerable<IBackplaneMethodResolver> _methodResolvers;
+
+        private readonly ConcurrentDictionary<string, BackplaneChannelRegistration> _subscriptions = new ConcurrentDictionary<string, BackplaneChannelRegistration>();
+
+        public BackplaneChannel(JsonSerializer jsonSerializer, IServerIdManager serverIdManager, IMessageBus messageBus, IEnumerable<IBackplaneMethodResolver> methodResolvers)
+        {
+            _jsonSerializer = jsonSerializer;
+            _serverIdManager = serverIdManager;
+            _messageBus = messageBus;
+            _methodResolvers = methodResolvers;
+        }
+
+        public void Subscribe()
+        {
+            _messageBus.Subscribe(this, cursor: null, callback: HandleMessages, maxMessages: 10, state: null);
+        }
+
+        public void Subscribe<T>(T instance) where T : IDisposable
+        {
+            Subscribe(instance, channelName: null);
+        }
+
+        public void Subscribe<T>(T instance, string channelName) where T : IDisposable
+        {
+            if (string.IsNullOrEmpty(channelName))
+            {
+                channelName = typeof(T).FullName;
+            }
+
+            var channelRegistration = new BackplaneChannelRegistration
+            {
+                Name = channelName,
+                Instance = instance,
+                Type = typeof(T)
+            };
+
+            // overwrite the last registration
+            _subscriptions.AddOrUpdate(channelName, channelRegistration, (key, reg) => channelRegistration);
+        }
+
+        public void Unsubscribe<T>(T instance) where T : IDisposable
+        {
+            foreach (var key in _subscriptions.Keys)
+            {
+                if (_subscriptions[key].Instance == (object)instance)
+                {
+                    BackplaneChannelRegistration channelRegistration;
+                    _subscriptions.TryRemove(key, out channelRegistration);
+                }
+            }
+        }
+
+        public void Unsubscribe(string channelName)
+        {
+            BackplaneChannelRegistration channelRegistration;
+            _subscriptions.TryRemove(channelName, out channelRegistration);
+        }
+
+        public void Invoke<T>(string methodName, object[] arguments)
+        {
+            Invoke(typeof(T).FullName, methodName, arguments);
+        }
+
+        public void Invoke(string channelName, string methodName, object[] arguments)
+        {
+            var message = new BackplaneChannelMessage
+            {
+                ChannelName = channelName,
+                MethodName = methodName,
+                Arguments = arguments.Select(e => _jsonSerializer.Stringify(e)).ToArray()
+            };
+            SendMessage(message);
+        }
+
+        private Task<bool> HandleMessages(MessageResult result, object state)
+        {
+            result.Messages.Enumerate<object>(
+                m => _signals.Any(s => s == m.Key),
+                (s, m) =>
+                {
+                    // ignore the message if we sent it in the first place
+                    if (m.Source == _serverIdManager.ServerId)
+                    {
+                        return;
+                    }
+
+                    // find a subscription
+                    var message = _jsonSerializer.Parse<BackplaneChannelMessage>(m.Value, m.Encoding);
+                    InvokeMethod(message.ChannelName, message.MethodName, message.Arguments);
+                },
+                state: null);
+
+            return Task.FromResult(true);
+        }
+
+        private void InvokeMethod(string channelName, string methodName, string[] arguments)
+        {
+            BackplaneChannelRegistration subscription;
+            if (!_subscriptions.TryGetValue(channelName, out subscription))
+            {
+                // if we can't find the channel, do nothing
+                return;
+            }
+
+            BackplaneMethodRegistration method = null;
+            int argumentCount = arguments != null ? arguments.Length : 0;
+            if (_methodResolvers.FirstOrDefault(p => p.TryGetMethod(subscription, methodName, argumentCount, out method)) == null)
+            {
+                return;
+            }
+
+            // deserialize parameters
+            var deserializedArguments = new object[method.ArgumentTypes.Length];
+
+            for (var idx = 0; idx < arguments.Length; idx++)
+            {
+                using (var paramReader = new StringReader(arguments[idx]))
+                {
+                    deserializedArguments[idx] = _jsonSerializer.Deserialize(paramReader, method.ArgumentTypes[idx]);
+                }
+            }
+
+            method.Invoker(subscription, deserializedArguments);
+        }
+
+        private void SendMessage<T>(T message)
+        {
+            _messageBus.Publish(new Message(_serverIdManager.ServerId, BackplaneSignal, _jsonSerializer.Stringify(message)));
+        }
+
+        event Action<ISubscriber, string> ISubscriber.EventKeyAdded
+        {
+            add { }
+            remove { }
+        }
+
+        event Action<ISubscriber, string> ISubscriber.EventKeyRemoved
+        {
+            add { }
+            remove { }
+        }
+
+        IList<string> ISubscriber.EventKeys
+        {
+            get
+            {
+                return _signals;
+            }
+        }
+
+        string ISubscriber.Identity
+        {
+            get
+            {
+                return _serverIdManager.ServerId;
+            }
+        }
+
+        Subscription ISubscriber.Subscription { get; set; }
+
+        Action<TextWriter> ISubscriber.WriteCursor { get; set; }
+
+        private class BackplaneChannelMessage
+        {
+            public string ChannelName { get; set; }
+            public string MethodName { get; set; }
+            public string[] Arguments { get; set; }
+        }
+    }
+}

--- a/JabbR/Infrastructure/BackplaneChannelRegistration.cs
+++ b/JabbR/Infrastructure/BackplaneChannelRegistration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace JabbR.Infrastructure
+{
+    public class BackplaneChannelRegistration
+    {
+        public string Name { get; set; }
+
+        public object Instance { get; set; }
+
+        public Type Type { get; set; }
+    }
+}

--- a/JabbR/Infrastructure/BackplaneMethodRegistration.cs
+++ b/JabbR/Infrastructure/BackplaneMethodRegistration.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace JabbR.Infrastructure
+{
+    public class BackplaneMethodRegistration
+    {
+        public Type ReturnType { get; set; }
+
+        public Type[] ArgumentTypes { get; set; }
+
+        public string MethodName { get; set; }
+
+        public virtual Func<BackplaneChannelRegistration, object[], object> Invoker { get; set; } 
+    }
+}

--- a/JabbR/Infrastructure/BackplaneReflectionMethodResolver.cs
+++ b/JabbR/Infrastructure/BackplaneReflectionMethodResolver.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Microsoft.AspNet.SignalR.Hubs;
+
+namespace JabbR.Infrastructure
+{
+    public class BackplaneReflectionMethodResolver : IBackplaneMethodResolver
+    {
+        private readonly ConcurrentDictionary<string, IDictionary<string, BackplaneMethodRegistration[]>> _methods;
+
+        private readonly ConcurrentDictionary<string, BackplaneMethodRegistration> _executableMethods;
+
+        public BackplaneReflectionMethodResolver()
+        {
+            _methods = new ConcurrentDictionary<string, IDictionary<string, BackplaneMethodRegistration[]>>();
+
+            _executableMethods = new ConcurrentDictionary<string, BackplaneMethodRegistration>();
+        }
+
+        public bool TryGetMethod(BackplaneChannelRegistration channelRegistration, string methodName, int argumentCount, out BackplaneMethodRegistration methodRegistration)
+        {
+            string cacheKey = string.Format(
+                "{0}::{1}({2})",
+                channelRegistration.Name,
+                methodName,
+                argumentCount);
+
+            if (!_executableMethods.TryGetValue(cacheKey, out methodRegistration))
+            {
+                BackplaneMethodRegistration[] matches;
+                var methodCache = _methods.GetOrAdd(channelRegistration.Name, key => BuildMethodCacheFor(channelRegistration));
+                if (methodCache.TryGetValue(methodName, out matches))
+                {
+                    methodRegistration = matches[0];
+                }
+            }
+
+            return methodRegistration != null;
+        }
+
+        private IDictionary<string, BackplaneMethodRegistration[]> BuildMethodCacheFor(BackplaneChannelRegistration channelRegistration)
+        {
+            return channelRegistration.Type
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .GroupBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key,
+                              group => group.Select(methodInfo => new BackplaneMethodRegistration
+                              {
+                                  MethodName = methodInfo.Name,
+                                  ArgumentTypes = methodInfo.GetParameters().Select(p => p.ParameterType).ToArray(),
+                                  ReturnType = methodInfo.ReturnType,
+                                  Invoker = (channel, arguments) => methodInfo.Invoke(channel.Instance, arguments)
+                              }).ToArray(),
+                              StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/JabbR/Infrastructure/IBackplaneChannel.cs
+++ b/JabbR/Infrastructure/IBackplaneChannel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace JabbR.Infrastructure
+{
+    public interface IBackplaneChannel
+    {
+        void Subscribe<T>(T instance) where T : IDisposable;
+
+        void Subscribe<T>(T instance, string channelName) where T : IDisposable;
+
+        void Unsubscribe<T>(T instance) where T : IDisposable;
+
+        void Unsubscribe(string channelName);
+
+        void Invoke<T>(string methodName, object[] arguments);
+
+        void Invoke(string channelName, string methodName, object[] arguments);
+    }
+}

--- a/JabbR/Infrastructure/IBackplaneMethodResolver.cs
+++ b/JabbR/Infrastructure/IBackplaneMethodResolver.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace JabbR.Infrastructure
+{
+    public interface IBackplaneMethodResolver
+    {
+        bool TryGetMethod(BackplaneChannelRegistration channelRegistration, string methodName, int argumentCount, out BackplaneMethodRegistration methodInvoker);
+    }
+}

--- a/JabbR/Infrastructure/NullBackplaneChannel.cs
+++ b/JabbR/Infrastructure/NullBackplaneChannel.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace JabbR.Infrastructure
+{
+    public class NullBackplaneChannel : IBackplaneChannel
+    {
+        public void Subscribe<T>(T instance) where T : IDisposable
+        {
+        }
+
+        public void Subscribe<T>(T instance, string channelName) where T : IDisposable
+        {
+        }
+
+        public void Unsubscribe<T>(T instance) where T : IDisposable
+        {
+        }
+
+        public void Unsubscribe(string channelName)
+        {
+        }
+
+        public void Invoke<T>(string methodName, object[] arguments)
+        {
+        }
+
+        public void Invoke(string channelName, string methodName, object[] arguments)
+        {
+        }
+    }
+}

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -951,13 +951,20 @@
     <Compile Include="Commands\CheckBannedCommand.cs" />
     <Compile Include="Commands\UnBanCommand.cs" />
     <Compile Include="ContentProviders\ConfiguredContentProvider.cs" />
+    <Compile Include="Infrastructure\BackplaneChannelRegistration.cs" />
+    <Compile Include="Infrastructure\BackplaneChannel.cs" />
+    <Compile Include="Infrastructure\BackplaneMethodRegistration.cs" />
+    <Compile Include="Infrastructure\BackplaneReflectionMethodResolver.cs" />
     <Compile Include="Infrastructure\BinaryBlob.cs" />
     <Compile Include="Commands\MemeCommand.cs" />
     <Compile Include="Infrastructure\AuthenticationService.cs" />
     <Compile Include="Infrastructure\EnumerableExtensions.cs" />
     <Compile Include="Infrastructure\HttpServerUtility.cs" />
     <Compile Include="Infrastructure\IAuthenticationService.cs" />
+    <Compile Include="Infrastructure\IBackplaneChannel.cs" />
+    <Compile Include="Infrastructure\IBackplaneMethodResolver.cs" />
     <Compile Include="Infrastructure\JabbrUserIdProvider.cs" />
+    <Compile Include="Infrastructure\NullBackplaneChannel.cs" />
     <Compile Include="Infrastructure\StringReaderExtensions.cs" />
     <Compile Include="LanguageResources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -1099,6 +1106,7 @@
     <Compile Include="Nancy\NotificationsModule.cs" />
     <Compile Include="Nancy\SessionExtensions.cs" />
     <Compile Include="Services\ContentProviderSetting.cs" />
+    <Compile Include="Services\CacheProxy.cs" />
     <Compile Include="Services\DefaultUserAuthenticator.cs" />
     <Compile Include="Services\Email\Email.cs" />
     <Compile Include="Services\Email\EmailService.cs" />

--- a/JabbR/Services/CacheProxy.cs
+++ b/JabbR/Services/CacheProxy.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+using JabbR.Infrastructure;
+
+namespace JabbR.Services
+{
+    public class CacheProxy : ICache
+    {
+        private readonly IBackplaneChannel _backplaneChannel;
+
+        private readonly ICache _cache;
+
+        public CacheProxy(IBackplaneChannel backplaneChannel, ICache cache)
+        {
+            _backplaneChannel = backplaneChannel;
+            _cache = cache;
+
+            _backplaneChannel.Subscribe<ICache>(cache);
+        }
+
+        public void Remove(string key)
+        {
+            _cache.Remove(key);
+            _backplaneChannel.Invoke<ICache>("Remove", new object[] { key });
+        }
+
+        public object Get(string key)
+        {
+            return _cache.Get(key);
+        }
+
+        public void Set(string key, object value, TimeSpan expiresIn)
+        {
+            _cache.Set(key, value, expiresIn);
+        }
+
+        public void Dispose()
+        {
+            _backplaneChannel.Unsubscribe(_cache);
+        }
+    }
+}

--- a/JabbR/Services/ChatService.cs
+++ b/JabbR/Services/ChatService.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+
+using JabbR.Infrastructure;
 using JabbR.Models;
 using JabbR.UploadHandlers;
 using Microsoft.AspNet.SignalR;
@@ -293,7 +295,7 @@ namespace JabbR.Services
         public ChatService(ICache cache, IRecentMessageCache recentMessageCache, IJabbrRepository repository)
             : this(cache,
                    recentMessageCache,
-                   repository,  
+                   repository,
                    ApplicationSettings.GetDefaultSettings())
         {
         }
@@ -402,9 +404,6 @@ namespace JabbR.Services
 
         public void LeaveRoom(ChatUser user, ChatRoom room)
         {
-            // Update the cache
-            _cache.RemoveUserInRoom(user, room);
-
             // Remove the user from this room
             _repository.RemoveUserRoom(user, room);
 
@@ -413,6 +412,9 @@ namespace JabbR.Services
             user.Preferences = userPreferences;
 
             _repository.CommitChanges();
+
+            // Update the cache
+            _cache.RemoveUserInRoom(user, room);
         }
 
         public void AddAttachment(ChatMessage message, string fileName, string contentType, long size, UploadResult result)

--- a/JabbR/Services/DefaultCache.cs
+++ b/JabbR/Services/DefaultCache.cs
@@ -31,5 +31,9 @@ namespace JabbR.Services
         {
             _cache.Remove(key);
         }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/JabbR/Services/ICache.cs
+++ b/JabbR/Services/ICache.cs
@@ -2,7 +2,7 @@
 
 namespace JabbR.Services
 {
-    public interface ICache
+    public interface ICache : IDisposable
     {
         object Get(string key);
         void Set(string key, object value, TimeSpan expiresIn);

--- a/JabbR/Services/IJabbrConfiguration.cs
+++ b/JabbR/Services/IJabbrConfiguration.cs
@@ -6,6 +6,7 @@ namespace JabbR.Services
     {
         bool RequireHttps { get; }
         bool MigrateDatabase { get; }
+        bool ScaleOut { get; }
 
         string DeploymentSha { get; }
         string DeploymentBranch { get; }
@@ -13,6 +14,7 @@ namespace JabbR.Services
 
         string ServiceBusConnectionString { get; }
         string ServiceBusTopicPrefix { get; }
+        bool ScaleOutServiceBus { get; }
 
         ConnectionStringSettings SqlConnectionString { get; }
         bool ScaleOutSqlServer { get; }

--- a/JabbR/Services/JabbrConfiguration.cs
+++ b/JabbR/Services/JabbrConfiguration.cs
@@ -73,6 +73,15 @@ namespace JabbR.Services
             }
         }
 
+        public bool ScaleOutServiceBus
+        {
+            get
+            {
+                return !String.IsNullOrEmpty(ServiceBusConnectionString) && 
+                    !String.IsNullOrEmpty(ServiceBusTopicPrefix);
+            }
+        }
+
         public bool ScaleOutSqlServer
         {
             get
@@ -84,6 +93,14 @@ namespace JabbR.Services
                     return scaleOutSqlServer;
                 }
                 return false;
+            }
+        }
+
+        public bool ScaleOut
+        {
+            get
+            {
+                return ScaleOutSqlServer || ScaleOutServiceBus;
             }
         }
 


### PR DESCRIPTION
Added some backplane communication for server-server communication.  Currently in a rough (but working) state.

Currently adds a singleton ChatServiceProxy class which both subscribes to and publishes events to the backplane communication (which is a singleton wrapper around the signalr message bus).  ChatService calls these methods when necessary.
