### PR TITLE
Auto room creation

### DIFF
--- a/JabbR/Chat.js
+++ b/JabbR/Chat.js
@@ -308,7 +308,7 @@
     };
 
     // Called when a returning users join chat
-    chat.client.logOn = function (rooms, myRooms, userPreferences) {
+    chat.client.logOn = function (rooms, myRooms, userPreferences, appSettings) {
         privateRooms = myRooms;
 
         var loadRooms = function () {
@@ -357,7 +357,7 @@
         ui.setUnreadNotifications(chat.state.unreadNotifications);
 
         // Process any urls that may contain room names
-        ui.run();
+        ui.run(appSettings);
 
         // Otherwise set the active room
         ui.setActiveRoom(this.state.activeRoom || 'Lobby');
@@ -1090,13 +1090,18 @@
         updateTitle();
     });
 
-    $ui.bind(ui.events.openRoom, function (ev, room) {
+    $ui.bind(ui.events.openRoom, function (ev, room, createIfNotExists) {
         try {
             chat.server.send('/join ' + room, chat.state.activeRoom)
                 .fail(function (e) {
-                    ui.setActiveRoom('Lobby');
-                    if (e.source === 'HubException') {
-                        ui.addErrorToActiveRoom(e.message);
+                    if (createIfNotExists) {
+                        $ui.trigger(ui.events.sendMessage, ["/create " + room, null, true]);
+                    }
+                    else {
+                        ui.setActiveRoom('Lobby');
+                        if (e.source === 'HubException') {
+                            ui.addErrorToActiveRoom(e.message);
+                        }
                     }
                 });
         }

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1339,13 +1339,12 @@
             }, trimRoomHistoryFrequency);
         },
         
-        run: function () {
+        run: function (appSettings) {
             $.history.init(function (hash) {
                 var roomName = getRoomNameFromHash(hash);
-
                 if (roomName) {
                     if (ui.setActiveRoomCore(roomName) === false && roomName !== 'Lobby') {
-                        $ui.trigger(ui.events.openRoom, [roomName]);
+                        $ui.trigger(ui.events.openRoom, [roomName, appSettings.AllowAutoRoomCreation]);
                     }
                 }
             });

--- a/JabbR/Hubs/Chat.cs
+++ b/JabbR/Hubs/Chat.cs
@@ -626,7 +626,7 @@ namespace JabbR
                 }
 
                 // Initialize the chat with the rooms the user is in
-                Clients.Caller.logOn(rooms, privateRooms, user.Preferences);
+                Clients.Caller.logOn(rooms, privateRooms, user.Preferences, new { _settings.AllowAutoRoomCreation });
             }
         }
 

--- a/JabbR/LanguageResources.Designer.cs
+++ b/JabbR/LanguageResources.Designer.cs
@@ -397,6 +397,24 @@ namespace JabbR {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow Auto Room Creation.
+        /// </summary>
+        public static string Administration_AllowAutoRoomCreation {
+            get {
+                return ResourceManager.GetString("Administration_AllowAutoRoomCreation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allows users to link to rooms that don&apos;t exist yet.
+        /// </summary>
+        public static string Administration_AllowAutoRoomCreation_Detail {
+            get {
+                return ResourceManager.GetString("Administration_AllowAutoRoomCreation_Detail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Allow Room Creation.
         /// </summary>
         public static string Administration_AllowRoomCreation {

--- a/JabbR/LanguageResources.resx
+++ b/JabbR/LanguageResources.resx
@@ -198,6 +198,12 @@
   <data name="Administration_AllowRoomCreation" xml:space="preserve">
     <value>Allow Room Creation</value>
   </data>
+  <data name="Administration_AllowAutoRoomCreation" xml:space="preserve">
+    <value>Allow Auto Room Creation</value>
+  </data>
+  <data name="Administration_AllowAutoRoomCreation_Detail" xml:space="preserve">
+    <value>Allows users to link to rooms that don't exist yet</value>
+  </data>
   <data name="Administration_AllowUserRegistration" xml:space="preserve">
     <value>Allow User Registration</value>
   </data>

--- a/JabbR/Services/ApplicationSettings.cs
+++ b/JabbR/Services/ApplicationSettings.cs
@@ -39,6 +39,8 @@ namespace JabbR.Services
 
         public bool AllowRoomCreation { get; set; }
 
+        public bool AllowAutoRoomCreation { get; set; }
+
         public string FacebookAppId { get; set; }
 
         public string FacebookAppSecret { get; set; }

--- a/JabbR/Views/Administration/index.cshtml
+++ b/JabbR/Views/Administration/index.cshtml
@@ -69,6 +69,13 @@
                         </div>
                     </div>
                     <div class="control-group">
+                        <label class="control-label" for="allowAutoRoomCreation">@LanguageResources.Administration_AllowAutoRoomCreation</label>
+                        <div class="controls">
+                            @Html.CheckBox("allowAutoRoomCreation", applicationSettings.AllowAutoRoomCreation)
+                            <span class="help-block">@LanguageResources.Administration_AllowAutoRoomCreation_Detail</span>
+                        </div>
+                    </div>
+                    <div class="control-group">
                         <label class="control-label" for="maxMessageLength">@LanguageResources.Administration_MaxMessageLength</label>
                         <div class="controls">
                             <input type="text" id="maxMessageLength" name="maxMessageLength" class="input-xlarge" value="@applicationSettings.MaxMessageLength" placeholder="@LanguageResources.Administration_MaxMessageLength"/>


### PR DESCRIPTION
Adds an "auto room creation" admistration option, which makes it so if a user loads jabbr with a room url for a room that does not exist, it is added automatically. This allows for dynamic urls to be used that invite users to discuss a topic without having to make the room in advance. The setting is disabled by default.

Note that this PR builds on top of my previous PR, #1078 because of changes to the administration index.cshtml. Recommend you take that one first if you are going to take both of these. 
