### PR TITLE
Reload content providers after saving admin

### DIFF
--- a/JabbR/App_Start/Startup.DependencyInjection.cs
+++ b/JabbR/App_Start/Startup.DependencyInjection.cs
@@ -1,4 +1,7 @@
-﻿using JabbR.ContentProviders;
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using JabbR.ContentProviders;
 using JabbR.ContentProviders.Core;
 using JabbR.Infrastructure;
 using JabbR.Models;
@@ -112,7 +115,9 @@ namespace JabbR
                       .To<SettingsKeyProvider>();
 
             kernel.Bind<IResourceProcessor>()
-                .ToConstant(new ResourceProcessor(kernel));
+                .To<ResourceProcessor>();
+
+            RegisterContentProviders(kernel);
 
             var serializer = JsonSerializer.Create(new JsonSerializerSettings()
             {
@@ -145,6 +150,30 @@ namespace JabbR
                   .To<EmailService>();
 
             return kernel;
+        }
+
+        private static void RegisterContentProviders(IKernel kernel)
+        {
+            kernel.Bind<IContentProvider>().To<AudioContentProvider>();
+            kernel.Bind<IContentProvider>().To<BashQDBContentProvider>();
+            kernel.Bind<IContentProvider>().To<BBCContentProvider>();
+            kernel.Bind<IContentProvider>().To<DictionaryContentProvider>();
+            kernel.Bind<IContentProvider>().To<GitHubIssueCommentsContentProvider>();
+            kernel.Bind<IContentProvider>().To<GitHubIssuesContentProvider>();
+            kernel.Bind<IContentProvider>().To<GoogleDocsFormProvider>();
+            kernel.Bind<IContentProvider>().To<GoogleDocsPresentationsContentProvider>();
+            kernel.Bind<IContentProvider>().To<GoogleMapsContentProvider>();
+            kernel.Bind<IContentProvider>().To<ImageContentProvider>();
+            kernel.Bind<IContentProvider>().To<ImgurContentProvider>();
+            kernel.Bind<IContentProvider>().To<NerdDinnerContentProvider>();
+            kernel.Bind<IContentProvider>().To<NugetNuggetContentProvider>();
+            kernel.Bind<IContentProvider>().To<ScreencastContentProvider>();
+            kernel.Bind<IContentProvider>().To<SlideShareContentProvider>();
+            kernel.Bind<IContentProvider>().To<SoundCloudContentProvider>();
+            kernel.Bind<IContentProvider>().To<SpotifyContentProvider>();
+            kernel.Bind<IContentProvider>().To<UserVoiceContentProvider>();
+            kernel.Bind<IContentProvider>().To<UStreamContentProvider>();
+            kernel.Bind<IContentProvider>().To<YouTubeContentProvider>();
         }
     }
 }

--- a/JabbR/ContentProviders/ConfiguredContentProvider.cs
+++ b/JabbR/ContentProviders/ConfiguredContentProvider.cs
@@ -1,21 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Text.RegularExpressions;
 using JabbR.ContentProviders.Core;
 using JabbR.Services;
-using Ninject;
 
 namespace JabbR.ContentProviders
 {
     public class ConfiguredContentProvider : EmbedContentProvider
     {
-        private readonly SettingsManager _settingsManager;
+        private readonly ISettingsManager _settingsManager;
 
-        [ImportingConstructor]
-        public ConfiguredContentProvider(IKernel kernel)
+        public ConfiguredContentProvider(ISettingsManager settingsManager)
         {
-            _settingsManager = kernel.Get<SettingsManager>();
+            _settingsManager = settingsManager;
         }
 
         private ApplicationSettings GetSettings()

--- a/JabbR/ContentProviders/Core/IContentProvider.cs
+++ b/JabbR/ContentProviders/Core/IContentProvider.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 
 namespace JabbR.ContentProviders.Core
 {
-    [InheritedExport]
     public interface IContentProvider
     {
         Task<ContentProviderResult> GetContent(ContentProviderHttpRequest request);

--- a/JabbR/ContentProviders/Core/ResourceProcessor.cs
+++ b/JabbR/ContentProviders/Core/ResourceProcessor.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.ComponentModel.Composition.Hosting;
 using System.Linq;
 using System.Threading.Tasks;
 using JabbR.Services;
-using Ninject;
 
 namespace JabbR.ContentProviders.Core
 {
     public class ResourceProcessor : IResourceProcessor
     {
+        private readonly ISettingsManager _settingsManager;
         private readonly IList<IContentProvider> _contentProviders;
 
-        public ResourceProcessor(IKernel kernel)
+        public ResourceProcessor(ISettingsManager settingsManager, IList<IContentProvider> contentProviders)
         {
-            _contentProviders = GetContentProviders(kernel);
+            _settingsManager = settingsManager;
+            _contentProviders = contentProviders;
         }
 
         public Task<ContentProviderResult> ExtractResource(string url)
@@ -32,7 +31,7 @@ namespace JabbR.ContentProviders.Core
 
         private Task<ContentProviderResult> ExtractContent(ContentProviderHttpRequest request)
         {
-            var validProviders = _contentProviders.Where(c => c.IsValidContent(request.RequestUri))
+            var validProviders = GetActiveContentProviders().Where(c => c.IsValidContent(request.RequestUri))
                                                   .ToList();
 
             if (validProviders.Count == 0)
@@ -66,20 +65,10 @@ namespace JabbR.ContentProviders.Core
             return tcs.Task;
         }
 
-        public static IList<IContentProvider> GetAllContentProviders(IKernel kernel)
+        private IList<IContentProvider> GetActiveContentProviders()
         {
-            // Use MEF to locate the content providers in this assembly
-            var compositionContainer = new CompositionContainer(new AssemblyCatalog(typeof(ResourceProcessor).Assembly));
-            compositionContainer.ComposeExportedValue(kernel);
-            compositionContainer.ComposeExportedValue(kernel.Get<ApplicationSettings>());
-            return compositionContainer.GetExportedValues<IContentProvider>()
-                .ToList();
-        }
-
-        private static IList<IContentProvider> GetContentProviders(IKernel kernel)
-        {
-            var applicationSettings = kernel.Get<ApplicationSettings>();
-            return GetAllContentProviders(kernel)
+            var applicationSettings = _settingsManager.Load();
+            return _contentProviders
                 .Where(cp => !applicationSettings.DisabledContentProviders.Contains(cp.GetType().Name))
                 .ToList();
         }

--- a/JabbR/ContentProviders/ImageContentProvider.cs
+++ b/JabbR/ContentProviders/ImageContentProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
@@ -17,7 +16,6 @@ namespace JabbR.ContentProviders
         private readonly IKernel _kernel;
         private readonly IJabbrConfiguration _configuration;
 
-        [ImportingConstructor]
         public ImageContentProvider(IKernel kernel)
         {
             _kernel = kernel;

--- a/JabbR/LanguageResources.Designer.cs
+++ b/JabbR/LanguageResources.Designer.cs
@@ -523,15 +523,6 @@ namespace JabbR {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enabling or Disabling a content provider will require an app restart to take effect.
-        /// </summary>
-        public static string Administration_ContentProviders_RequiresRestart {
-            get {
-                return ResourceManager.GetString("Administration_ContentProviders_RequiresRestart", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Script.
         /// </summary>
         public static string Administration_ContentProviders_Script {

--- a/JabbR/LanguageResources.resx
+++ b/JabbR/LanguageResources.resx
@@ -216,9 +216,6 @@
   <data name="Administration_ContentProviders_BuiltIn" xml:space="preserve">
     <value>Content Providers</value>
   </data>
-  <data name="Administration_ContentProviders_RequiresRestart" xml:space="preserve">
-    <value>Enabling or Disabling a content provider will require an app restart to take effect</value>
-  </data>
   <data name="Administration_ContentProviders_Custom" xml:space="preserve">
     <value>Custom Content Providers</value>
   </data>

--- a/JabbR/Nancy/AdministrationModule.cs
+++ b/JabbR/Nancy/AdministrationModule.cs
@@ -15,7 +15,8 @@ namespace JabbR.Nancy
     {
         public AdministrationModule(IKernel kernel,
                                     ApplicationSettings applicationSettings,
-                                    ISettingsManager settingsManager)
+                                    ISettingsManager settingsManager,
+                                    IEnumerable<IContentProvider> contentProviders)
             : base("/administration")
         {
             Get["/"] = _ =>
@@ -25,7 +26,7 @@ namespace JabbR.Nancy
                     return HttpStatusCode.Forbidden;
                 }
 
-                var allContentProviders = ResourceProcessor.GetAllContentProviders(kernel)
+                var allContentProviders = contentProviders
                     .OrderBy(provider => provider.GetType().Name)
                     .ToList();
                 var model = new
@@ -56,7 +57,7 @@ namespace JabbR.Nancy
                     
                     // we posted the enabled ones, but we store the disabled ones. Flip it around...
                     settings.DisabledContentProviders =
-                        new HashSet<string>(ResourceProcessor.GetAllContentProviders(kernel)
+                        new HashSet<string>(contentProviders
                             .Select(cp => cp.GetType().Name)
                             .Where(typeName => !enabledContentProvidersResult.EnabledContentProviders.Contains(typeName))
                             .ToList());

--- a/JabbR/Views/Administration/index.cshtml
+++ b/JabbR/Views/Administration/index.cshtml
@@ -205,7 +205,6 @@
                                         }
                                     </tbody>
                                 </table>
-                                <span>@LanguageResources.Administration_ContentProviders_RequiresRestart</span>
                             </div>
                         </fieldset>
                     </div>


### PR DESCRIPTION
Simple change to make it so enabling/disabling a built-in content provider does not require restarting the app.
