### PR TITLE
fix #1074 build.cmd issues with spaces in repository paths

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,5 +4,5 @@ if "%config%" == "" (
    set config=debug
 )
 
-.nuget\NuGet.exe restore JabbR.sln -configFile %~dp0\.nuget\NuGet.config -nocache
-msbuild %~dp0\Build\Build.proj /p:Configuration="%config%" /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
+.nuget\NuGet.exe restore JabbR.sln -configFile "%~dp0.nuget\NuGet.config" -nocache
+msbuild "%~dp0Build\Build.proj" /p:Configuration="%config%" /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false


### PR DESCRIPTION
Make build.cmd work when your path has spaces.  Fix double shashed arguments.
