### PR TITLE
Improve perf user status change

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1631,26 +1631,29 @@
         },
         setUserActivity: function (userViewModel) {
             var $user = $('.users .user' + getUserClassName(userViewModel.name)),
-                $inactiveSince = $user.find('.inactive-since'),
-                $userMessages = $('.message-user' + getUserClassName(userViewModel.name));
+                $inactiveSince = $user.find('.inactive-since');
 
             if (userViewModel.active === true && userViewModel.afk === false) {
                 if ($user.hasClass('inactive')) {
                     $user.removeClass('inactive');
                     $inactiveSince.livestamp('destroy');
                 }
-                
-                $userMessages.removeClass('offline active inactive').addClass('active');
+
+                $('.message-user' + getUserClassName(userViewModel.name))
+                    .removeClass('offline inactive')
+                    .addClass('active');
             } else {
                 if (!$user.hasClass('inactive')) {
                     $user.addClass('inactive');
+                    
+                    $('.message-user' + getUserClassName(userViewModel.name))
+                        .removeClass('offline active')
+                        .addClass('inactive');
                 }
 
                 if (!$inactiveSince.html()) {
                     $inactiveSince.livestamp(userViewModel.lastActive);
                 }
-                
-                $userMessages.removeClass('offline active inactive').addClass('inactive');
             }
 
             updateNote(userViewModel, $user);


### PR DESCRIPTION
Figured that I should at least make this into a PR.  What this does is only performs status updates to inactive only if the user was not previously marked as inactive.  This is to try to mitigate performance issues with the inactive updater process.

Might be superseded by other work on playing around with CSS rules directly.
