### PR TITLE
Add zero-width space character before and after matches for emoji aliases

### DIFF
--- a/JabbR/Chat.emoji.js
+++ b/JabbR/Chat.emoji.js
@@ -27,7 +27,7 @@
             for (var key in validAlias) {
                 if (validAlias.hasOwnProperty(key)) {
                     var regex = new RegExp(key, "g");
-                    content = content.replace(regex, validAlias[key]);
+                    content = content.replace(regex, '\u200B' + validAlias[key] + '\u200B');
                 }
             }
             


### PR DESCRIPTION
make it so that :)P doesn't evaluate to :smile:P (which then evaluates to :smile:tongue:, which gets shortened to :smile: tongue:).

Fixes #1054

Insert zero-width spaces before and after substituted tokens.
![croppercapture 5](https://cloud.githubusercontent.com/assets/1271535/3487085/c095ce2a-0462-11e4-8ebb-0e10a10766b9.jpg)
