### PR TITLE
Fix #1094

### DIFF
--- a/JabbR/Nancy/AdministrationModule.cs
+++ b/JabbR/Nancy/AdministrationModule.cs
@@ -59,7 +59,8 @@ namespace JabbR.Nancy
                     settings.DisabledContentProviders =
                         new HashSet<string>(contentProviders
                             .Select(cp => cp.GetType().Name)
-                            .Where(typeName => !enabledContentProvidersResult.EnabledContentProviders.Contains(typeName))
+                            .Where(typeName => enabledContentProvidersResult.EnabledContentProviders == null ||
+                                !enabledContentProvidersResult.EnabledContentProviders.Contains(typeName))
                             .ToList());
 
                     IDictionary<string, string> errors;


### PR DESCRIPTION
Make it so that all content providers can be disabled without an error.
