### PR TITLE
fix #1008

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -514,7 +514,11 @@
 
     function triggerFocus() {
         if (!utility.isMobile && !readOnly) {
-            $newMessage.focus();
+            if (getActiveRoomName() === 'Lobby') {
+                $roomFilterInput.focus();
+            } else {
+                $newMessage.focus();
+            }
         }
 
         if (focus === false) {


### PR DESCRIPTION
Focus the search textbox when the lobby is selected, otherwise focus on the chat message box.
