### PR TITLE
XKCD Content Provider support (take 2)

### DIFF
--- a/JabbR/App_Start/Startup.DependencyInjection.cs
+++ b/JabbR/App_Start/Startup.DependencyInjection.cs
@@ -175,6 +175,7 @@ namespace JabbR
             kernel.Bind<IContentProvider>().To<UStreamContentProvider>();
             kernel.Bind<IContentProvider>().To<YouTubeContentProvider>();
             kernel.Bind<IContentProvider>().To<ConfiguredContentProvider>();
+            kernel.Bind<IContentProvider>().To<XkcdContentProvider>();
         }
     }
 }

--- a/JabbR/ContentProviders/XkcdContentProvider.cs
+++ b/JabbR/ContentProviders/XkcdContentProvider.cs
@@ -67,7 +67,7 @@ namespace JabbR.ContentProviders
 
         public override bool IsValidContent(Uri uri)
         {
-            return uri.AbsoluteUri.Matches(@"https?:\/\/xkcd.com\/\d+\/");
+            return uri.AbsoluteUri.Matches(@"https?:\/\/xkcd.com\/\d+\/?");
         }
 
 

--- a/JabbR/ContentProviders/XkcdContentProvider.cs
+++ b/JabbR/ContentProviders/XkcdContentProvider.cs
@@ -15,7 +15,7 @@ namespace JabbR.ContentProviders
         private static readonly string ContentFormat = @"
 <div class=""xkcd_wrapper"">
     <div class=""xkcd_header"">
-        <a href=""{0}"" target=""_blank""><img src=""{1}"" title=""{3}"" /></a>
+        <a href=""{0}"" target=""_blank""><img src=""{1}"" title=""{2}"" /></a>
     </div>
 </div>";
 
@@ -30,7 +30,7 @@ namespace JabbR.ContentProviders
 
                 return new ContentProviderResult
                 {
-                    Content = String.Format(ContentFormat, request.RequestUri.ToString(),  pageInfo.ImageUrl, pageInfo.Title, pageInfo.Description),
+                    Content = String.Format(ContentFormat, request.RequestUri.ToString(),  pageInfo.ImageUrl, pageInfo.Description),
                     Title = pageInfo.Title
                 };
             });

--- a/JabbR/ContentProviders/XkcdContentProvider.cs
+++ b/JabbR/ContentProviders/XkcdContentProvider.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Threading.Tasks;
+using HtmlAgilityPack;
+using JabbR.ContentProviders.Core;
+using JabbR.Infrastructure;
+using RestSharp.Extensions;
+
+namespace JabbR.ContentProviders
+{
+    /// <summary>
+    /// Content provider that will embed the XKCD comic linked
+    /// </summary>
+    public class XkcdContentProvider : CollapsibleContentProvider
+    {
+        private static readonly string ContentFormat = @"
+<div class=""xkcd_wrapper"">
+    <div class=""xkcd_header"">
+        <a href=""{0}"" target=""_blank""><img src=""{1}"" title=""{3}"" /></a>
+    </div>
+</div>";
+
+        protected override System.Threading.Tasks.Task<ContentProviderResult> GetCollapsibleContent(ContentProviderHttpRequest request)
+        {
+            return ExtractFromResponse(request).Then(pageInfo =>
+            {
+                if (pageInfo == null)
+                {
+                    return null;
+                }
+
+                return new ContentProviderResult
+                {
+                    Content = String.Format(ContentFormat, request.RequestUri.ToString(),  pageInfo.ImageUrl, pageInfo.Title, pageInfo.Description),
+                    Title = pageInfo.Title
+                };
+            });
+        }
+
+        private Task<XkcdContentProvider.XkcdComicInfo> ExtractFromResponse(ContentProviderHttpRequest request)
+        {
+            return Http.GetAsync(request.RequestUri).Then(response =>
+            {
+                var comicInfo = new XkcdComicInfo();
+
+                using (var responseStream = response.GetResponseStream())
+                {
+                    var htmlDocument = new HtmlDocument();
+                    htmlDocument.Load(responseStream);
+                    htmlDocument.OptionFixNestedTags = true;
+
+                    var comic = htmlDocument.DocumentNode.SelectSingleNode("//div[@id='comic']/img");
+                                            
+                    if (comic == null)
+                    {
+                        return null;
+                    }
+
+                    comicInfo.Title = comic.Attributes["alt"].Value;
+                    comicInfo.ImageUrl = comic.Attributes["src"].Value;
+                    comicInfo.Description = comic.Attributes["title"].Value;
+
+                }
+
+                return comicInfo;
+            });
+        }
+
+        public override bool IsValidContent(Uri uri)
+        {
+            return uri.AbsoluteUri.Matches(@"https?:\/\/xkcd.com\/\d+\/");
+        }
+
+
+        private class XkcdComicInfo
+        {
+            public string Title { get; set; }
+            public string ImageUrl { get; set; }
+            public string Description { get; set; }
+
+        }
+    }
+}

--- a/JabbR/JabbR.csproj
+++ b/JabbR/JabbR.csproj
@@ -988,6 +988,7 @@
     <Compile Include="Commands\CheckBannedCommand.cs" />
     <Compile Include="Commands\UnBanCommand.cs" />
     <Compile Include="ContentProviders\ConfiguredContentProvider.cs" />
+    <Compile Include="ContentProviders\XkcdContentProvider.cs" />
     <Compile Include="Infrastructure\BinaryBlob.cs" />
     <Compile Include="Commands\MemeCommand.cs" />
     <Compile Include="Infrastructure\AuthenticationService.cs" />


### PR DESCRIPTION
Heavily based off the existing Bash content provider, although no longer quite so much @khellang :)

![Looks like this](https://jabbrlive.blob.core.windows.net/jabbr-uploads/clipboard_f3b8.png)

Has alt text as the title of the image, so no spoilers.
