### PR TITLE
Display a users owned rooms on their profile page.

### DIFF
--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -372,6 +372,8 @@ canvas {
 
 #owned-rooms li {
     cursor: default;
+    width: 240px;
+    margin: 0 10px;
 }
 
     @-webkit-keyframes room-fade
@@ -451,7 +453,7 @@ canvas {
 #userlist-lobby-owners li div.room-row,
 #owned-rooms li div.room-row {
     display: inline-block;
-    width: 240px;
+    width: 250px;
     padding: 5px;
     border: 1px solid #e5e5e5;
 }

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -337,11 +337,16 @@ canvas {
 }
 
 #userlist-lobby,
-#userlist-lobby-owners {
+#userlist-lobby-owners,
+#owned-rooms {
     position: relative;
     margin: 0 5px;
     top: 10px;
     background: none;
+}
+
+#owned-rooms {
+    top: 0;
 }
 
     #userlist-lobby li {
@@ -353,7 +358,8 @@ canvas {
         cursor: pointer;
     }
 
-    #userlist-lobby-owners li {
+    #userlist-lobby-owners li,
+    #owned-rooms li {
         display: inline-block;
         margin: 0 5px 10px 5px;
         height: 102px;
@@ -363,6 +369,10 @@ canvas {
         -webkit-animation-play-state: paused;
         cursor: pointer;
     }
+
+#owned-rooms li {
+    cursor: default;
+}
 
     @-webkit-keyframes room-fade
     {
@@ -391,7 +401,6 @@ canvas {
             background: none;
         }
 
-
     #userlist-lobby div.room-row {
         min-height: 30px;
         border-color: #EEEEEE;
@@ -401,6 +410,7 @@ canvas {
         padding-top: 5px;
         padding-left: 15px;
     }
+
 
     #userlist-lobby div:hover {
         background: #e5e5e5;
@@ -438,7 +448,8 @@ canvas {
             color: rgba(0, 16, 63, 1);
         }
 
-#userlist-lobby-owners li div.room-row {
+#userlist-lobby-owners li div.room-row,
+#owned-rooms li div.room-row {
     display: inline-block;
     width: 250px;
     padding: 5px;
@@ -451,7 +462,8 @@ canvas {
         color: rgba(0, 16, 63, 1);
     }
 
-#userlist-lobby-owners li div.room-row div {
+#userlist-lobby-owners li div.room-row div,
+#owned-rooms li div.room-row div {
         width: 100%;
         margin: 0;
     }
@@ -462,7 +474,8 @@ canvas {
 }
 
 #userlist-lobby .name,
-#userlist-lobby-owners .name {
+#userlist-lobby-owners .name,
+#owned-rooms .name {
     font-size: 1.25em;
     overflow: hidden;
     width: 215px;
@@ -480,12 +493,14 @@ canvas {
 }
 
 #userlist-lobby .topic,
-#userlist-lobby-owners .topic {
+#userlist-lobby-owners .topic,
+#owned-rooms .topic {
     font-size: 1em;
     overflow: hidden;
 }
 
-#userlist-lobby-owners .topic {
+#userlist-lobby-owners .topic,
+#owned-rooms .topic {
     width: 250px;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -451,7 +451,7 @@ canvas {
 #userlist-lobby-owners li div.room-row,
 #owned-rooms li div.room-row {
     display: inline-block;
-    width: 250px;
+    width: 240px;
     padding: 5px;
     border: 1px solid #e5e5e5;
 }

--- a/JabbR/LanguageResources.Designer.cs
+++ b/JabbR/LanguageResources.Designer.cs
@@ -178,6 +178,15 @@ namespace JabbR {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Owned Rooms.
+        /// </summary>
+        public static string Account_OwnedRooms {
+            get {
+                return ResourceManager.GetString("Account_OwnedRooms", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Password.
         /// </summary>
         public static string Account_Pass {

--- a/JabbR/LanguageResources.resx
+++ b/JabbR/LanguageResources.resx
@@ -1278,4 +1278,7 @@ Use ? or type /? to display the FAQ and list of commands.</value>
   <data name="Client_DownloadMessagesNotOpen" xml:space="preserve">
     <value>{0} is not an open room, messages cannot be downloaded.</value>
   </data>
+  <data name="Account_OwnedRooms" xml:space="preserve">
+    <value>Owned Rooms</value>
+  </data>
 </root>

--- a/JabbR/ViewModels/ProfilePageViewModel.cs
+++ b/JabbR/ViewModels/ProfilePageViewModel.cs
@@ -23,6 +23,7 @@ namespace JabbR.ViewModels
             IsAdmin = user.IsAdmin;
             SocialDetails = new SocialLoginViewModel(configuredProviders, user.Identities);
             HasPassword = user.HasUserNameAndPasswordCredentials();
+            OwnedRooms = user.OwnedRooms;
         }
 
         public bool HasPassword { get; private set; }
@@ -38,5 +39,7 @@ namespace JabbR.ViewModels
         public DateTime LastActivity { get; private set; }
         public bool IsAdmin { get; private set; }
         public SocialLoginViewModel SocialDetails { get; private set; }
+
+        public ICollection<ChatRoom> OwnedRooms { get; private set; }
     }
 }

--- a/JabbR/Views/Account/index.cshtml
+++ b/JabbR/Views/Account/index.cshtml
@@ -59,7 +59,7 @@
                                 <div class="control-group">
                                     <label class="control-label" for="note">@LanguageResources.Account_Note</label>
                                     <div class="controls">
-                                        @if(userModel.Note != null)
+                                        @if (userModel.Note != null)
                                         {
                                             <label class="control-label label-align-left">@userModel.Note</label>
                                         }
@@ -79,10 +79,39 @@
                                         else
                                         {
                                             <div class="alert alert-info span5">To set your country, type /flag [iso-3366-2 code] <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2" target="_blank">ISO Reference Chart</a></div>
-                                        }                                            
+                                        }
                                     </div>
                                 </div>
                             </form>
+                            @if(userModel.OwnedRooms.Count > 0)
+                            {
+                                <fieldset>
+                                    <legend>Owned Rooms</legend>
+                                    <ul id="owned-rooms" class="unstyled">
+                                        @foreach (var room in userModel.OwnedRooms)
+                                        {
+                                            <li class="room">
+                                                <div class="row-fluid room-row">
+                                                    <div class="span3">
+                                                        <span class="name">@room.Name</span>
+                                                        @if(room.Private)
+                                                        {
+                                                            <span class="lock"><i class="icon-lock"></i></span>
+                                                        }
+                                                        @if(room.Closed)
+                                                        {
+                                                            <span class="readonly"><i class="icon-ban-circle"></i></span>
+                                                        }
+                                                    </div>
+                                                    <div class="span4">
+                                                        <span class="topic">@room.Topic</span>
+                                                    </div>
+                                                </div>
+                                            </li>
+                                        }
+                                    </ul>
+                                </fieldset>
+                            }
                         </div>
                         <div class="account-details tab-pane hide" id="changeUsername">
                             <form class="form-horizontal" action="@Url.Content("~/account/changeusername")#changeUsername" method="POST">

--- a/JabbR/Views/Account/index.cshtml
+++ b/JabbR/Views/Account/index.cshtml
@@ -56,32 +56,35 @@
                     <div class="tab-content">
                         <div class="account-details tab-pane active" id="profile">
                             <form class="form-horizontal">
-                                <div class="control-group">
-                                    <label class="control-label" for="note">@LanguageResources.Account_Note</label>
-                                    <div class="controls">
-                                        @if (userModel.Note != null)
-                                        {
-                                            <label class="control-label label-align-left">@userModel.Note</label>
-                                        }
-                                        else
-                                        {
-                                            <div class="alert alert-info span5">To set your note, type /note [message]</div>
-                                        }
+                                <fieldset>
+                                    <legend>@LanguageResources.Administration_GeneralSettings</legend>
+                                    <div class="control-group">
+                                        <label class="control-label label-align-left" for="note">@LanguageResources.Account_Note</label>
+                                        <div class="controls">
+                                            @if (userModel.Note != null)
+                                            {
+                                                <span class="input-xxlarge uneditable-input">@userModel.Note</span>
+                                            }
+                                            else
+                                            {
+                                                <div class="alert alert-info">To set your note, type /note [message]</div>
+                                            }
+                                        </div>
                                     </div>
-                                </div>
-                                <div class="control-group">
-                                    <label class="control-label" for="country">@LanguageResources.Account_Country</label>
-                                    <div class="controls">
-                                        @if (userModel.Country != null)
-                                        {
-                                            <p>@userModel.Country <span class="flag flag-@userModel.Flag"></span></p>
-                                        }
-                                        else
-                                        {
-                                            <div class="alert alert-info span5">To set your country, type /flag [iso-3366-2 code] <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2" target="_blank">ISO Reference Chart</a></div>
-                                        }
+                                    <div class="control-group">
+                                        <label class="control-label label-align-left" for="country">@LanguageResources.Account_Country</label>
+                                        <div class="controls">
+                                            @if (userModel.Country != null)
+                                            {
+                                                <span class="input-medium uneditable-input"><span>@userModel.Country</span> <i class="flag flag-@userModel.Flag"></i></span>
+}
+                                            else
+                                            {
+                                                <div class="alert alert-info">To set your country, type /flag [iso-3366-2 code] <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2" target="_blank">ISO Reference Chart</a></div>
+                                            }
+                                        </div>
                                     </div>
-                                </div>
+                                </fieldset>
                             </form>
                             @if(userModel.OwnedRooms.Count > 0)
                             {

--- a/JabbR/Views/Account/index.cshtml
+++ b/JabbR/Views/Account/index.cshtml
@@ -86,7 +86,7 @@
                             @if(userModel.OwnedRooms.Count > 0)
                             {
                                 <fieldset>
-                                    <legend>Owned Rooms</legend>
+                                    <legend>@LanguageResources.Account_OwnedRooms</legend>
                                     <ul id="owned-rooms" class="unstyled">
                                         @foreach (var room in userModel.OwnedRooms)
                                         {


### PR DESCRIPTION
Will show as:
![image](https://cloud.githubusercontent.com/assets/1035315/3625540/a175e506-0e6d-11e4-883c-d4d1201fbf56.png)

The rooms are not links that you can click to open the room, I thought as this would open a new tab (i.e. not in the browser tab that JabbR is currently open in) you would end up with a number of tabs open.

But if others think that the rooms should be links opening the room, then I'll make the change.

 Fixes #718 
