### PR TITLE
Add a create room button to the UI

### DIFF
--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -78,7 +78,8 @@
         roomLoadingTimeout = null,
         Room = chat.Room,
         $unreadNotificationCount = null,
-        $splashScreen = null;
+        $splashScreen = null,
+        $createRoomButton = null;
 
     function getRoomNameFromHash(hash) {
         if (hash.length && hash[0] === '/') {
@@ -849,6 +850,8 @@
             $splashScreen = $('#splash-screen');
 
             $unreadNotificationCount = $('#notification-unread-count');
+
+            $createRoomButton = $('#create-room');
             
             if (toast.canToast()) {
                 $toast.show();
@@ -1191,6 +1194,19 @@
                 $('<iframe style="display:none">').attr('src', url).appendTo(document.body);
 
                 $downloadDialog.modal('hide');
+            });
+
+            $createRoomButton.click(function () {
+                var roomName = prompt(utility.getLanguageResource('Create_CommandInfo')),
+                    msg = '/create ' + roomName;
+                if (roomName === null) {
+                    return false;
+                }
+                else if (roomName === '') {
+                    alert(utility.getLanguageResource('RoomNameCannotBeBlank'));
+                } else {
+                    $ui.trigger(ui.events.sendMessage, [msg, null, true]);
+                }
             });
 
             $logout.click(function () {

--- a/JabbR/Chat.ui.js
+++ b/JabbR/Chat.ui.js
@@ -1424,6 +1424,7 @@
                     if (currentRoom.isLobby()) {
                         $lobbyRoomFilterForm.hide();
                         $roomActions.show();
+                        $createRoomButton.hide();
                     }
                 }
 
@@ -1433,6 +1434,7 @@
 
                 if (room.isLobby()) {
                     $roomActions.hide();
+                    $createRoomButton.show();
                     $lobbyRoomFilterForm.show();
 
                     room.messages.hide();

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -2759,10 +2759,15 @@ h3.userlist-header {
     background-repeat: no-repeat;
 }
 
-#room-actions {
+#room-actions,
+#create-room {
     margin-right: 5px;
     top: 8px;
     display: none;
+}
+
+#create-room {
+    display: block;
 }
 
 #room-preferences .sound:hover .icon-sound {

--- a/JabbR/Content/themes/default/Chat.css
+++ b/JabbR/Content/themes/default/Chat.css
@@ -2759,15 +2759,14 @@ h3.userlist-header {
     background-repeat: no-repeat;
 }
 
-#room-actions,
-#create-room {
+#room-actions {
     margin-right: 5px;
     top: 8px;
     display: none;
 }
 
 #create-room {
-    display: block;
+    top: 2px;
 }
 
 #room-preferences .sound:hover .icon-sound {

--- a/JabbR/Nancy/HomeModule.cs
+++ b/JabbR/Nancy/HomeModule.cs
@@ -19,7 +19,7 @@ namespace JabbR.Nancy
 {
     public class HomeModule : JabbRModule
     {
-        private static readonly Regex clientSideResourceRegex = new Regex("^(Client_.*|Chat_.*|Content_.*|LoadingMessage)$");
+        private static readonly Regex clientSideResourceRegex = new Regex("^(Client_.*|Chat_.*|Content_.*|Create_.*|LoadingMessage|Room.*)$");
 
         public HomeModule(ApplicationSettings settings,
                           IJabbrConfiguration configuration,
@@ -41,7 +41,8 @@ namespace JabbR.Nancy
                         Version = Constants.JabbRVersion,
                         IsAdmin = Principal.HasClaim(JabbRClaimTypes.Admin),
                         ClientLanguageResources = BuildClientResources(),
-                        MaxMessageLength = settings.MaxMessageLength
+                        MaxMessageLength = settings.MaxMessageLength,
+                        AllowRoomCreation = settings.AllowRoomCreation
                     };
 
                     return View["index", viewModel];

--- a/JabbR/Nancy/HomeModule.cs
+++ b/JabbR/Nancy/HomeModule.cs
@@ -42,7 +42,7 @@ namespace JabbR.Nancy
                         IsAdmin = Principal.HasClaim(JabbRClaimTypes.Admin),
                         ClientLanguageResources = BuildClientResources(),
                         MaxMessageLength = settings.MaxMessageLength,
-                        AllowRoomCreation = settings.AllowRoomCreation
+                        AllowRoomCreation = settings.AllowRoomCreation || Principal.HasClaim(JabbRClaimTypes.Admin)
                     };
 
                     return View["index", viewModel];

--- a/JabbR/ViewModels/SettingsViewModel.cs
+++ b/JabbR/ViewModels/SettingsViewModel.cs
@@ -13,6 +13,7 @@ namespace JabbR.ViewModels
         public bool DebugMode { get; set; }
         public Version Version { get; set; }
         public bool IsAdmin { get; set; }
+        public bool AllowRoomCreation { get; set; }
         public string ClientLanguageResources { get; set; }
         public int MaxMessageLength { get; set; }
      

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -382,6 +382,12 @@
                     <input id="room-filter-closed" type="checkbox" />
                     @LanguageResources.Client_ShowClosedRooms
                 </label>
+                @if (Model.AllowRoomCreation)
+                {
+                    <div id="create-room" class="btn-group pull-right">
+                        <button class="btn btn-small"><i class="icon-plus"></i> Create Room</button>
+                    </div>
+                }
             </form>
             <div id="room-actions" class="btn-group pull-right">
                 <button class="btn btn-small dropdown-toggle" data-toggle="dropdown">@LanguageResources.Client_RoomSettings <span class="caret"></span></button>
@@ -392,11 +398,6 @@
                     <li><a class="download" title="download messages" aria-haspopup="true"><i class="icon-download"></i> @LanguageResources.Client_DownloadMessages</a></li>
                 </ul>
             </div>
-            @if (Model.AllowRoomCreation) {
-                <div id="create-room" class="btn-group pull-right">
-                    <button class="btn btn-small"><i class="icon-plus"></i> Create Room</button>
-                </div>
-            }
             <div id="room-loading">
                 <div id="loader-container">
                     <canvas id="canvas" width="150" height="150"></canvas>

--- a/JabbR/Views/Home/index.cshtml
+++ b/JabbR/Views/Home/index.cshtml
@@ -392,6 +392,11 @@
                     <li><a class="download" title="download messages" aria-haspopup="true"><i class="icon-download"></i> @LanguageResources.Client_DownloadMessages</a></li>
                 </ul>
             </div>
+            @if (Model.AllowRoomCreation) {
+                <div id="create-room" class="btn-group pull-right">
+                    <button class="btn btn-small"><i class="icon-plus"></i> Create Room</button>
+                </div>
+            }
             <div id="room-loading">
                 <div id="loader-container">
                     <canvas id="canvas" width="150" height="150"></canvas>


### PR DESCRIPTION
The button will be visible on the lobby, and also when in a room (as you
might still want to create a new room while in another room)

In the lobby
![image](https://cloud.githubusercontent.com/assets/1035315/3634290/f389efa0-0f20-11e4-8ae5-86f7ec52ccd7.png)

In a room
![image](https://cloud.githubusercontent.com/assets/1035315/3634292/018511ca-0f21-11e4-81ce-a6948a37251b.png)

Creating a new room
![image](https://cloud.githubusercontent.com/assets/1035315/3634389/e2bb3ba8-0f29-11e4-9f00-c88fdd4fc03f.png)

Without entering a room name
![image](https://cloud.githubusercontent.com/assets/1035315/3634390/fcefc44e-0f29-11e4-8d2b-87b108bfb3ec.png)

Entering a room name
![image](https://cloud.githubusercontent.com/assets/1035315/3634395/24200d76-0f2a-11e4-934e-b19c8050e48e.png)

![image](https://cloud.githubusercontent.com/assets/1035315/3634397/2abbb662-0f2a-11e4-86b3-08cef041f22b.png)

Trying to create a room that already exists
![image](https://cloud.githubusercontent.com/assets/1035315/3634398/3fc6bc64-0f2a-11e4-80af-b326aed7f88a.png)

Fix #1154.
