### PR TITLE
Remove unused dependency

### DIFF
--- a/JabbR/Nancy/AdministrationModule.cs
+++ b/JabbR/Nancy/AdministrationModule.cs
@@ -7,14 +7,12 @@ using JabbR.Infrastructure;
 using JabbR.Services;
 using Nancy;
 using Nancy.ModelBinding;
-using Ninject;
 
 namespace JabbR.Nancy
 {
     public class AdministrationModule : JabbRModule
     {
-        public AdministrationModule(IKernel kernel,
-                                    ApplicationSettings applicationSettings,
+        public AdministrationModule(ApplicationSettings applicationSettings,
                                     ISettingsManager settingsManager,
                                     IEnumerable<IContentProvider> contentProviders)
             : base("/administration")


### PR DESCRIPTION
As of 78458fe1023d00b4fca79f40d250e7d1e3484abb the `IKernel` dependency is no longer used
