### PR TITLE
Optimal twitter scrollToBottom using twitter 'rendered' event

### DIFF
--- a/JabbR/Chat.twitter.js
+++ b/JabbR/Chat.twitter.js
@@ -1,13 +1,15 @@
-﻿(function ($, window, ui) {
+(function ($, window, ui) {
     "use strict";
+
+    // Prevent multiple global events from being bound
+    var twitterRenderBound = false;
 
     window.addTweet = function (tweet) {
         // Keep track of whether we're near the end, so we can auto-scroll once the tweet is added.
-        var nearEnd = ui.isNearTheEnd(),
-            elements = null,
+        var elements = null,
             tweetSegment = '/statuses/',
+            currentMessages = $('.messages.current'),
             id = tweet.url.substring(tweet.url.indexOf(tweetSegment) + tweetSegment.length);
-
 
         // Grab any elements we need to process.
         elements = $('div.tweet_' + id)
@@ -17,9 +19,15 @@
         // Process the template, and add it in to the div.
         $('#tweet-template').tmpl(tweet).appendTo(elements);
 
-        // If near the end, scroll.
-        if (nearEnd) {
-            ui.scrollToBottom();
+        //Checking 'twttr' reference because of dynamic Twitter API script
+        if (window.twttr && !twitterRenderBound) {
+            twitterRenderBound = true;
+            twttr.events.bind('rendered', function (event) {
+                if (currentMessages.scrollTop() + currentMessages.outerHeight() > currentMessages[0].scrollHeight - $(event.target).outerHeight() - 30)
+                {
+                    ui.scrollToBottom();
+                }
+            });
         }
     };
 


### PR DESCRIPTION
Problem : Chatting a link (that will be embedded as a tweet) doesn't work properly; even if you are scrolled to the bottom of the chat, a tweet can easily cause you to stop seeing the latest messages by not properly scrolling you to the bottom of the chat after the tweet.  This also forces you to scroll to see all subsequent messages.

Here's what happens to the scrollbar in an empty chat even with just a single tweet posted in chrome.

![Scroll To Bottom Issue](http://i.imgur.com/B2dcKR4.png)

Cause : Embedded tweets are loading a dynamic script and, in the current Chat.twitter.js, it tries to scroll to the bottom prior to letting the tweet fully render.  Larger tweets (images,videos) seem to exacerbate this problem.

Solution : Binding the (poorly documented) 'rendered' event from the dynamic twttr object allows you to get the exact size of the tweet that's being embedded.  You can use that to determine whether or not to scroll to the bottom.  It will consistently keep your chat flowing downward as new tweets are posted when you're scrolled to the bottom.

Concerns : Still needs a magic constant just like the $.fn.isNearTheEnd in Chat.utility.js.  Is somewhat of a copy of $.fn.isNearTheEnd.  It creates a new jquery selector whereas the prior code did not.
