### PR TITLE
Author positioning was poorly floating.

### DIFF
--- a/JabbR/Content/themes/default/Chat.nuget.css
+++ b/JabbR/Content/themes/default/Chat.nuget.css
@@ -118,10 +118,6 @@
     width: 50%;
 }
 
-.nuget-authors-entry { 
-    float: left; 
-}
-
 .nuget-ProjectUrl {
     font-size: 80%;
     text-align: left;

--- a/JabbR/ContentProviders/NugetNuggetContentProvider.cs
+++ b/JabbR/ContentProviders/NugetNuggetContentProvider.cs
@@ -32,7 +32,7 @@ namespace JabbR.ContentProviders
                         }
 
                         var projectInfo = new StringBuilder();
-                        projectInfo.AppendFormat("<div class=\"nuget-authors\" ><span>Authors: </span><div class=\"nuget-authors-entry\">{0}</div></div>",
+                        projectInfo.AppendFormat("<div class=\"nuget-authors\" ><span>Authors: </span>{0}</div>",
                                                  packageInfo.Authors);
                         projectInfo.AppendFormat("<div class=\"nuget-downloads\" ><span># Downloads:</span> {0}</div>",
                                                  packageInfo.DownloadCount);


### PR DESCRIPTION
Here's a screen shot of the NuGet content provider in JabbR (before the PR) ....

![image](https://cloud.githubusercontent.com/assets/899878/4243860/7f401b36-3a15-11e4-88f0-23791af21f79.png)

Noce the poor positioning of the author names? I tried this with the Json.NET package and it was doing the same thing.

So i just removed the `div` which had a `float` css key/value that seemed to be messing things up.

I just tested this with Chrome Dev Tools, playing around with the html/css values.

_Apologies: for not creating an Issue, first. Change seemed pretty small._
