### PR TITLE
put quote around MSBUILD_PATH to avoid space issue

### DIFF
--- a/deploy.cmd
+++ b/deploy.cmd
@@ -70,9 +70,9 @@ echo Handling .NET Web Application deployment.
 
 :: 1. Build to the temporary path
 IF /I "%IN_PLACE_DEPLOYMENT%" NEQ "1" (
-  %MSBUILD_PATH% "%DEPLOYMENT_SOURCE%\JabbR\JabbR.csproj" /nologo /verbosity:m /t:Build /t:pipelinePreDeployCopyAllFilesToOneFolder /p:_PackageTempDir="%DEPLOYMENT_TEMP%";AutoParameterizationWebConfigConnectionStrings=false;Configuration=Release /p:SolutionDir="%DEPLOYMENT_SOURCE%\.\\" %SCM_BUILD_ARGS%
+  "%MSBUILD_PATH%" "%DEPLOYMENT_SOURCE%\JabbR\JabbR.csproj" /nologo /verbosity:m /t:Build /t:pipelinePreDeployCopyAllFilesToOneFolder /p:_PackageTempDir="%DEPLOYMENT_TEMP%";AutoParameterizationWebConfigConnectionStrings=false;Configuration=Release /p:SolutionDir="%DEPLOYMENT_SOURCE%\.\\" %SCM_BUILD_ARGS%
 ) ELSE (
-  %MSBUILD_PATH% "%DEPLOYMENT_SOURCE%\JabbR\JabbR.csproj" /nologo /verbosity:m /t:Build /p:AutoParameterizationWebConfigConnectionStrings=false;Configuration=Release /p:SolutionDir="%DEPLOYMENT_SOURCE%\.\\" %SCM_BUILD_ARGS%
+  "%MSBUILD_PATH%" "%DEPLOYMENT_SOURCE%\JabbR\JabbR.csproj" /nologo /verbosity:m /t:Build /p:AutoParameterizationWebConfigConnectionStrings=false;Configuration=Release /p:SolutionDir="%DEPLOYMENT_SOURCE%\.\\" %SCM_BUILD_ARGS%
 )
 
 IF !ERRORLEVEL! NEQ 0 goto error


### PR DESCRIPTION
With latest Azure WebApps, MSBUILD_PATH is under program files directory.   Fix to address space issue when calling MSBUILD_PATH.
